### PR TITLE
[VCDA-2577] User refresh token at top level functions

### DIFF
--- a/cmd/ccm/main.go
+++ b/cmd/ccm/main.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package main

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:0.1.0.latest
+          image: harbor-repo.vmare.com/vcloud/cloud-provider-for-cloud-director:0.1.0.shamasundara.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vmware-cloud-director-ccm
-          image: harbor-repo.vmare.com/vcloud/cloud-provider-for-cloud-director:0.1.0.shamasundara.latest
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:0.1.0.shamasundara.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vmware-cloud-director-ccm
-          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:0.1.0.shamasundara.latest
+          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:0.1.0.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:0.1.0.latest
+          image: harbor-repo.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:0.1.0.shamasundara.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:0.1.0.latest
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:0.1.0.shamasundara.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/vcloud-basic-auth.yaml
+++ b/manifests/vcloud-basic-auth.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   username: ""
   password: ""
+  refreshToken: ""

--- a/pkg/ccm/cloud.go
+++ b/pkg/ccm/cloud.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 // +build !testing
@@ -59,7 +59,6 @@ func newVCDCloudProvider(configReader io.Reader) (cloudProvider.Interface, error
 			time.Sleep(10 * time.Second)
 			continue
 		}
-
 
 		if cloudConfig.LB.OneArm != nil {
 			oneArm = &vcdclient.OneArm{

--- a/pkg/ccm/cloud.go
+++ b/pkg/ccm/cloud.go
@@ -75,6 +75,7 @@ func newVCDCloudProvider(configReader io.Reader) (cloudProvider.Interface, error
 			cloudConfig.VCD.VIPSubnet,
 			cloudConfig.VCD.User,
 			cloudConfig.VCD.Secret,
+			cloudConfig.VCD.RefreshToken,
 			true,
 			cloudConfig.ClusterID,
 			oneArm,

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package ccm
@@ -26,7 +26,7 @@ func newInstances(vmInfoCache *VmInfoCache) cloudProvider.Instances {
 }
 
 func getUUIDFromProviderID(providerID string) string {
-	withoutPrefix := strings.TrimPrefix(providerID, ProviderName + "://")
+	withoutPrefix := strings.TrimPrefix(providerID, ProviderName+"://")
 	return strings.ToLower(strings.TrimSpace(withoutPrefix))
 }
 

--- a/pkg/ccm/k8shelper.go
+++ b/pkg/ccm/k8shelper.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 // +build !testing

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 // +build !testing

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -56,6 +56,9 @@ func (lb *LBManager) getNodeIPs() ([]string, error) {
 func (lb *LBManager) EnsureLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
 
+	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
+		return
+	}
 	nodeIPs, err := lb.getNodeIPs()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get nodes in cluster: [%v]", err)
@@ -94,6 +97,9 @@ func (lb *LBManager) getLBPoolNamePrefix(serviceName string, clusterID string) s
 // Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager
 func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (err error) {
+	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
+		return
+	}
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(service.Name, lb.vcdClient.ClusterID)
 	nodeIps := lb.getNodeInternalIps(nodes)
 	klog.Infof("UpdateLoadBalancer Node Ips: %v", nodeIps)
@@ -119,6 +125,9 @@ func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 func (lb *LBManager) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string,
 	service *v1.Service) error {
 
+	if err := lb.vcdClient.RefreshBearerToken(); err != nil {
+		return err
+	}
 	return lb.deleteLoadBalancer(ctx, service)
 }
 
@@ -152,6 +161,9 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
 
+	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
+		return
+	}
 	return lb.getLoadBalancer(ctx, service)
 }
 

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -57,7 +57,7 @@ func (lb *LBManager) EnsureLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
 
 	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
-		return
+		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	nodeIPs, err := lb.getNodeIPs()
 	if err != nil {
@@ -98,7 +98,7 @@ func (lb *LBManager) getLBPoolNamePrefix(serviceName string, clusterID string) s
 func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (err error) {
 	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
-		return
+		return fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(service.Name, lb.vcdClient.ClusterID)
 	nodeIps := lb.getNodeInternalIps(nodes)
@@ -126,7 +126,7 @@ func (lb *LBManager) EnsureLoadBalancerDeleted(ctx context.Context, clusterName 
 	service *v1.Service) error {
 
 	if err := lb.vcdClient.RefreshBearerToken(); err != nil {
-		return err
+		return fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	return lb.deleteLoadBalancer(ctx, service)
 }
@@ -162,7 +162,7 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
 
 	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
-		return
+		return nil, false, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	return lb.getLoadBalancer(ctx, service)
 }

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package ccm
@@ -38,7 +38,7 @@ type VmInfoCache struct {
 
 func newVmInfoCache(client *vcdclient.Client, expiry time.Duration) *VmInfoCache {
 	return &VmInfoCache{
-		expiry: expiry,
+		expiry:    expiry,
 		nameMap:   make(map[string]*VmInfo),
 		uuidMap:   make(map[string]*VmInfo),
 		vcdClient: client,
@@ -66,15 +66,15 @@ func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, captureTime time.Time) (*VmInf
 		vmAddresses := make([]v1.NodeAddress, 0)
 		for _, netConn := range vm.VM.NetworkConnectionSection.NetworkConnection {
 			v1helper.AddToNodeAddresses(&vmAddresses,
-				v1.NodeAddress {
+				v1.NodeAddress{
 					Type:    v1.NodeInternalIP,
 					Address: netConn.IPAddress,
 				},
-				v1.NodeAddress {
+				v1.NodeAddress{
 					Type:    v1.NodeExternalIP,
 					Address: netConn.IPAddress,
 				},
-				v1.NodeAddress {
+				v1.NodeAddress{
 					Type:    v1.NodeHostName,
 					Address: vm.VM.Name,
 				})

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -102,7 +102,7 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 
 	captureTime := time.Now()
 	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	vm, err := vmic.vcdClient.FindVMByName(vmName)
 	if err != nil {
@@ -145,7 +145,7 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 
 	captureTime := time.Now()
 	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	vm, err := vmic.vcdClient.FindVMByUUID(vmUUID)
 	if err != nil {

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -101,6 +101,9 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 	}
 
 	captureTime := time.Now()
+	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
+		return nil, err
+	}
 	vm, err := vmic.vcdClient.FindVMByName(vmName)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
@@ -141,6 +144,9 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 	}
 
 	captureTime := time.Now()
+	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
+		return nil, err
+	}
 	vm, err := vmic.vcdClient.FindVMByUUID(vmUUID)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package config
@@ -71,21 +71,23 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 }
 
 func SetAuthorization(config *CloudConfig) error {
+	var refreshToken, username, secret []byte
 	refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
-	if err != nil{
-		return fmt.Errorf("unable to get refresh token: [%v]", err)
-	}
-	username, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
 	if err != nil {
-		return fmt.Errorf("unable to get username: [%v]", err)
+		// Couldn't find refresh token. See if username and password can be obtained.
+		username, err = ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
+		if err != nil {
+			return fmt.Errorf("unable to get refresh token or username: [%v]", err)
+		}
+		secret, err = ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
+		if err != nil {
+			return fmt.Errorf("unable to get refresh token or password: [%v]", err)
+		}
+		config.VCD.User = string(username)
+		config.VCD.Secret = string(secret)
+	} else {
+		config.VCD.RefreshToken = string(refreshToken)
 	}
-	secret, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
-	if err != nil {
-		return fmt.Errorf("unable to get password: [%v]", err)
-	}
-	config.VCD.RefreshToken = string(refreshToken)
-	config.VCD.User = string(username)
-	config.VCD.Secret = string(secret)
 	return nil
 }
 

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -10,6 +10,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
+	"k8s.io/klog"
 )
 
 // VCDConfig :
@@ -74,14 +75,15 @@ func SetAuthorization(config *CloudConfig) error {
 	var refreshToken, username, secret []byte
 	refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
 	if err != nil {
+		klog.Infof("unable to get refresh token. Looking for username and password")
 		// Couldn't find refresh token. See if username and password can be obtained.
 		username, err = ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
 		if err != nil {
-			return fmt.Errorf("unable to get refresh token or username: [%v]", err)
+			return fmt.Errorf("unable to get username: [%v]", err)
 		}
 		secret, err = ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
 		if err != nil {
-			return fmt.Errorf("unable to get refresh token or password: [%v]", err)
+			return fmt.Errorf("unable to get password: [%v]", err)
 		}
 		config.VCD.User = string(username)
 		config.VCD.Secret = string(secret)

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"k8s.io/klog"
+	"os"
 )
 
 // VCDConfig :
@@ -72,24 +73,27 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 }
 
 func SetAuthorization(config *CloudConfig) error {
-	var refreshToken, username, secret []byte
-	refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
-	if err != nil {
-		klog.Infof("unable to get refresh token. Looking for username and password")
-		// Couldn't find refresh token. See if username and password can be obtained.
-		username, err = ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
+	// check if refresh token is present.
+	if _, err := os.Stat("/etc/kubernetes/vcloud/basic-auth/refreshToken"); err == nil {
+		// refresh token is present. Populate only refresh token and keep user and secret empty
+		refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
 		if err != nil {
-			return fmt.Errorf("unable to get username: [%v]", err)
+			return fmt.Errorf("unable to get refresh token: [%v]", err)
 		}
-		secret, err = ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
-		if err != nil {
-			return fmt.Errorf("unable to get password: [%v]", err)
-		}
-		config.VCD.User = string(username)
-		config.VCD.Secret = string(secret)
-	} else {
 		config.VCD.RefreshToken = string(refreshToken)
+		return nil
 	}
+	klog.Infof("unable to get refresh token. Looking for username and password")
+	username, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
+	if err != nil {
+		return fmt.Errorf("unable to get username: [%v]", err)
+	}
+	secret, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
+	if err != nil {
+		return fmt.Errorf("unable to get password: [%v]", err)
+	}
+	config.VCD.User = string(username)
+	config.VCD.Secret = string(secret)
 	return nil
 }
 

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -71,6 +71,10 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 }
 
 func SetAuthorization(config *CloudConfig) error {
+	refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
+	if err != nil{
+		return fmt.Errorf("unable to get refresh token: [%v]", err)
+	}
 	username, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
 	if err != nil {
 		return fmt.Errorf("unable to get username: [%v]", err)
@@ -79,6 +83,7 @@ func SetAuthorization(config *CloudConfig) error {
 	if err != nil {
 		return fmt.Errorf("unable to get password: [%v]", err)
 	}
+	config.VCD.RefreshToken = string(refreshToken)
 	config.VCD.User = string(username)
 	config.VCD.Secret = string(secret)
 	return nil

--- a/pkg/config/cloudconfig_test.go
+++ b/pkg/config/cloudconfig_test.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package config

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package util

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -194,6 +194,9 @@ func isAdminUser(vcdClient *govcd.VCDClient) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("error while getting current session [%v]", err)
 	}
+	if len(output.Roles) == 0 {
+		return false, fmt.Errorf("no roles associated with the user: [%v]", err)
+	}
 	isSysAdmin := output.Roles[0] == "System Administrator"
 	return isSysAdmin, nil
 }

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -45,7 +45,7 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 
 	var resp *http.Response
 	if config.RefreshToken != "" {
-		// Since it is not known if the user is sysadmin, try to get the access token using tenanted endpoint
+		// Since it is not known if the user is sysadmin, try to get the access token using provider endpoint
 		accessTokenResponse, resp, err := config.getAccessTokenFromRefreshToken(true)
 		if err != nil {
 			// Failed to get token as provider. Try to get token as tenant user
@@ -60,7 +60,7 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 		}
 		vcdClient.Client.IsSysAdmin, err = isAdminUser(vcdClient)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to determine if the user is an admin: [%v]", err)
+			return nil, nil, fmt.Errorf("failed to determine if the user is a system administrator: [%v]", err)
 		}
 
 		klog.Infof("Running CPI as sysadmin [%v]", vcdClient.Client.IsSysAdmin)

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -7,9 +7,12 @@ package vcdclient
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -20,6 +23,7 @@ import (
 type VCDAuthConfig struct {
 	User         string `json:"user"`
 	Password     string `json:"password"`
+	RefreshToken	string `json:"refreshToken"`
 	Org          string `json:"org"`
 	Host         string `json:"host"`
 	CloudAPIHref string `json:"cloudapihref"`
@@ -28,7 +32,7 @@ type VCDAuthConfig struct {
 	Token        string `json:"token"`
 }
 
-func (config *VCDAuthConfig) GetBearerTokenFromSecrets() (*govcd.VCDClient, *http.Response, error) {
+func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response, error) {
 	href := fmt.Sprintf("%s/api", config.Host)
 	u, err := url.ParseRequestURI(href)
 	if err != nil {
@@ -39,22 +43,41 @@ func (config *VCDAuthConfig) GetBearerTokenFromSecrets() (*govcd.VCDClient, *htt
 	vcdClient.Client.APIVersion = "35.0"
 	klog.Infof("Using VCD OpenAPI version [%s]", vcdClient.Client.APIVersion)
 
-	resp, err := vcdClient.GetAuthResponse(config.User, config.Password, config.Org)
-	if err != nil {
-		return nil, resp, fmt.Errorf("unable to authenticate [%s/%s] for url [%s]: [%+v] : [%v]",
-			config.Org, config.User, href, resp, err)
+	var resp *http.Response
+	if config.RefreshToken != "" {
+		// Authenticate using refresh token
+		accessTokenResponse, resp, err := config.getAccessTokenFromRefreshToken()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get access token from refresh token [%s]: [%v]", config.RefreshToken, err)
+		}
+		err = vcdClient.SetToken(config.Org, "Authorization", fmt.Sprintf("Bearer %s", accessTokenResponse.AccessToken))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to set authorization header: [%v]", err)
+		}
+		return vcdClient, resp, nil
+	} else {
+		resp, err := vcdClient.GetAuthResponse(config.User, config.Password, config.Org)
+		if err != nil {
+			return nil, resp, fmt.Errorf("unable to authenticate [%s/%s] for url [%s]: [%+v] : [%v]",
+				config.Org, config.User, href, resp, err)
+		}
 	}
-
 	return vcdClient, resp, nil
 }
 
 func (config *VCDAuthConfig) GetSwaggerClientFromSecrets() (*govcd.VCDClient, *swaggerClient.APIClient, error) {
 
-	vcdClient, _, err := config.GetBearerTokenFromSecrets()
+	vcdClient, _, err := config.GetBearerToken()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to get bearer token from serets: [%v]", err)
 	}
-	authHeader := fmt.Sprintf("Bearer %s", vcdClient.Client.VCDToken)
+	var authHeader string
+	if config.RefreshToken == "" {
+		authHeader = fmt.Sprintf("Bearer %s", vcdClient.Client.VCDToken)
+	} else {
+		authHeader = vcdClient.Client.VCDToken
+	}
+
 
 	swaggerConfig := swaggerClient.NewConfiguration()
 	swaggerConfig.BasePath = fmt.Sprintf("%s/cloudapi", config.Host)
@@ -86,11 +109,56 @@ func (config *VCDAuthConfig) GetPlainClientFromSecrets() (*govcd.VCDClient, erro
 	return vcdClient, nil
 }
 
-func NewVCDAuthConfigFromSecrets(host string, user string, secret string, org string, insecure bool) *VCDAuthConfig {
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType  string `json:"token_type"`
+	ExpiresIn  int32 `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+func (config *VCDAuthConfig) getAccessTokenFromRefreshToken() (*tokenResponse, *http.Response, error) {
+	accessTokenUrl := ""
+	if strings.ToLower(config.Org) == "system" {
+		accessTokenUrl = fmt.Sprintf("%s/oauth/provider/token", config.Host)
+	} else {
+		accessTokenUrl = fmt.Sprintf("%s/oauth/tenant/%s/token", config.Host, config.Org)
+	}
+
+	payload := url.Values{}
+	payload.Set("grant_type", "refresh_token")
+	payload.Set("refresh_token", config.RefreshToken)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	r, err := http.NewRequest("POST", accessTokenUrl, strings.NewReader(payload.Encode())) // URL-encoded payload
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get access token from refresh token: [%v]", err)
+	}
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	res, err := client.Do(r)
+	if err != nil {
+		return nil, res, err
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, res, err
+	}
+	var accessTokenResponse tokenResponse
+	if err = json.Unmarshal(body, &accessTokenResponse); err != nil {
+		return nil, res, err
+	}
+	return &accessTokenResponse, res, nil
+}
+
+func NewVCDAuthConfigFromSecrets(host string, user string, secret string, refreshToken string, org string, insecure bool) *VCDAuthConfig {
 	return &VCDAuthConfig{
 		Host:     host,
 		User:     user,
 		Password: secret,
+		RefreshToken: refreshToken,
 		Org:      org,
 		Insecure: insecure,
 	}

--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -18,6 +18,12 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"refreshToken": "",
+	})
+	assert.NoError(t, err, "Unable to get VCD Client")
+	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"getVdcClient": true,
 	})
 	assert.NoError(t, err, "Unable to get Client with VDC details.")

--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient
@@ -16,6 +16,11 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 	vcdClient, err := getTestVCDClient(nil)
 	assert.NoError(t, err, "Unable to get VCD client")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"getVdcClient": true,
+	})
+	assert.NoError(t, err, "Unable to get Client with VDC details.")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": "",

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient
@@ -46,7 +46,7 @@ type Client struct {
 
 // RefreshToken will check if can authenticate and rebuild clients if needed
 func (client *Client) RefreshToken() error {
-	_, r, err := client.vcdAuthConfig.GetBearerTokenFromSecrets()
+	_, r, err := client.vcdAuthConfig.GetBearerToken()
 	if r == nil && err != nil {
 		return fmt.Errorf("error while getting bearer token from secrets: [%v]", err)
 	} else if r != nil && r.StatusCode == 401 {
@@ -80,8 +80,8 @@ func (client *Client) RefreshToken() error {
 // NewVCDClientFromSecrets :
 func NewVCDClientFromSecrets(host string, orgName string, vdcName string,
 	networkName string, ipamSubnet string, user string, password string,
-	insecure bool, clusterID string, oneArm *OneArm, httpPort int32,
-	httpsPort int32, certAlias string, getVdcClient bool) (*Client, error) {
+	refreshToken string, insecure bool, clusterID string, oneArm *OneArm,
+	httpPort int32, httpsPort int32, certAlias string, getVdcClient bool) (*Client, error) {
 
 	// TODO: validation of parameters
 
@@ -96,12 +96,13 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string,
 			clientSingleton.vcdAuthConfig.VDC == vdcName &&
 			clientSingleton.vcdAuthConfig.User == user &&
 			clientSingleton.vcdAuthConfig.Password == password &&
+			clientSingleton.vcdAuthConfig.RefreshToken == refreshToken &&
 			clientSingleton.vcdAuthConfig.Insecure == insecure {
 			return clientSingleton, nil
 		}
 	}
 
-	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, user, password, orgName, insecure)
+	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, user, password, refreshToken, orgName, insecure)
 
 	vcdClient, apiClient, err := vcdAuthConfig.GetSwaggerClientFromSecrets()
 	if err != nil {

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -8,7 +8,6 @@ package vcdclient
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog"
 	"sync"
 
 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
@@ -44,36 +43,19 @@ type Client struct {
 	rwLock             sync.RWMutex
 }
 
-// RefreshToken will check if can authenticate and rebuild clients if needed
-func (client *Client) RefreshToken() error {
-	_, r, err := client.vcdAuthConfig.GetBearerToken()
-	if r == nil && err != nil {
-		return fmt.Errorf("error while getting bearer token from secrets: [%v]", err)
-	} else if r != nil && r.StatusCode == 401 {
-		klog.Info("Refreshing tokens as previous one has expired")
-		client.vcdClient.Client.APIVersion = "35.0"
-		err := client.vcdClient.Authenticate(client.vcdAuthConfig.User,
-			client.vcdAuthConfig.Password, client.vcdAuthConfig.Org)
-		if err != nil {
-			return fmt.Errorf("unable to Authenticate user [%s]: [%v]",
-				client.vcdAuthConfig.User, err)
-		}
-
-		org, err := client.vcdClient.GetOrgByNameOrId(client.vcdAuthConfig.Org)
-		if err != nil {
-			return fmt.Errorf("unable to get vcd organization [%s]: [%v]",
-				client.vcdAuthConfig.Org, err)
-		}
-
-		vdc, err := org.GetVDCByName(client.vcdAuthConfig.VDC, true)
-		if err != nil {
-			return fmt.Errorf("unable to get vdc from org [%s], vdc [%s]: [%v]",
-				client.vcdAuthConfig.Org, client.vcdAuthConfig.VDC, err)
-		}
-
-		client.vdc = vdc
+func (client *Client) RefreshBearerToken() error {
+	// No need to refresh token if logged in using username and password
+	if client.vcdAuthConfig.User != "" && client.vcdAuthConfig.Password != "" && client.vcdAuthConfig.RefreshToken == "" {
+		return nil
 	}
-
+	accessTokenResponse, _, err := client.vcdAuthConfig.getAccessTokenFromRefreshToken(client.vcdClient.Client.IsSysAdmin)
+	if err != nil {
+		return fmt.Errorf("failed to refresh access token: [%v]", err)
+	}
+	err = client.vcdClient.SetToken(client.vcdAuthConfig.Org, "Authorization", fmt.Sprintf("Bearer %s", accessTokenResponse.AccessToken))
+	if err != nil {
+		return fmt.Errorf("failed to set authorization header: [%v]", err)
+	}
 	return nil
 }
 

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -8,11 +8,11 @@ package vcdclient
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog"
 	"sync"
 
 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
-	"k8s.io/klog"
 )
 
 var (
@@ -124,12 +124,6 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string,
 	}
 
 	if getVdcClient {
-		// this new client is only needed to get the vdc pointer
-		vcdClient, err = vcdAuthConfig.GetPlainClientFromSecrets()
-		if err != nil {
-			return nil, fmt.Errorf("unable to get plain client from secrets: [%v]", err)
-		}
-
 		org, err := vcdClient.GetOrgByName(orgName)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get org from name [%s]: [%v]", orgName, err)
@@ -141,7 +135,6 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string,
 		}
 	}
 	client.vcdClient = vcdClient
-
 	// We will specifically cache the gateway ID that corresponds to the
 	// network name since it is used frequently in the loadbalancer context.
 	ctx := context.Background()

--- a/pkg/vcdclient/common_system_test.go
+++ b/pkg/vcdclient/common_system_test.go
@@ -1,15 +1,16 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient
 
 import (
 	"fmt"
-	"github.com/vmware/cloud-provider-for-cloud-director/pkg/config"
 	"os"
 	"path/filepath"
+
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/config"
 )
 
 var (

--- a/pkg/vcdclient/common_system_test.go
+++ b/pkg/vcdclient/common_system_test.go
@@ -105,6 +105,8 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 				cloudConfig.LB.CertificateAlias = getStrValStrict(val, cloudConfig.LB.CertificateAlias)
 			case "getVdcClient":
 				getVdcClient = getBoolValStrict(val, false)
+			case "refreshToken":
+				cloudConfig.VCD.RefreshToken = getStrValStrict(val, cloudConfig.VCD.RefreshToken)
 			}
 		}
 	}
@@ -117,6 +119,7 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 		cloudConfig.VCD.VIPSubnet,
 		cloudConfig.VCD.User,
 		cloudConfig.VCD.Secret,
+		cloudConfig.VCD.RefreshToken,
 		insecure,
 		cloudConfig.ClusterID,
 		oneArm,

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient
@@ -8,18 +8,18 @@ package vcdclient
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 
+	"github.com/antihax/optional"
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/peterhellberg/link"
 
-	"github.com/antihax/optional"
 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
-	"k8s.io/klog"
 )
 
 // CacheGatewayDetails : get gateway reference and cache some details in client object
@@ -1204,7 +1204,7 @@ func (client *Client) removeVirtualIpFromRDE(ctx context.Context, removeIp strin
 		if foundIdx == -1 {
 			return nil // no need to update RDE
 		}
-		updatedIps := append(currIps[:foundIdx], currIps[foundIdx + 1:]...)
+		updatedIps := append(currIps[:foundIdx], currIps[foundIdx+1:]...)
 
 		httpResponse, err := client.updateRDEVirtualIps(ctx, updatedIps, etag, defEnt)
 		if err != nil {

--- a/pkg/vcdclient/gateway_system_test.go
+++ b/pkg/vcdclient/gateway_system_test.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient
@@ -183,7 +183,7 @@ func TestGetUnusedGatewayIP(t *testing.T) {
 	return
 }
 
-	func TestVirtualServiceHttpCRUDE(t *testing.T) {
+func TestVirtualServiceHttpCRUDE(t *testing.T) {
 
 	vcdClient, err := getTestVCDClient(nil)
 	assert.NoError(t, err, "Unable to get VCD client")
@@ -254,7 +254,7 @@ func foundStringInSlice(find string, slice []string) bool {
 			return true
 		}
 	}
-	return  false
+	return false
 }
 
 func TestVirtualServiceHttpsCRUDE(t *testing.T) {
@@ -358,7 +358,6 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 	assert.NoError(t, err, "HTTP Load Balancer should be updated")
 	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", updatedIps, updatedInternalPort)
 	assert.NoError(t, err, "HTTPS Load Balancer should be updated")
-
 
 	err = vcdClient.DeleteLoadBalancer(ctx, virtualServiceNamePrefix,
 		lbPoolNamePrefix)

--- a/pkg/vcdclient/gateway_unit_test.go
+++ b/pkg/vcdclient/gateway_unit_test.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient

--- a/pkg/vcdclient/vms.go
+++ b/pkg/vcdclient/vms.go
@@ -23,10 +23,6 @@ func (client *Client) FindVMByName(vmName string) (*govcd.VM, error) {
 		return nil, fmt.Errorf("vmName mandatory for FindVMByName")
 	}
 
-	if err := client.RefreshToken(); err != nil {
-		return nil, fmt.Errorf("unable to refresh vcd token: [%v]", err)
-	}
-
 	// Query is be delimited to org where user exists. The expectation is that
 	// there will be exactly one VM with that name.
 	results, err := client.vdc.QueryWithNotEncodedParams(
@@ -63,10 +59,6 @@ func (client *Client) FindVMByName(vmName string) (*govcd.VM, error) {
 func (client *Client) FindVMByUUID(vcdVmUUID string) (*govcd.VM, error) {
 	if vcdVmUUID == "" {
 		return nil, fmt.Errorf("vmUUID mandatory for FindVMByUUID")
-	}
-
-	if err := client.RefreshToken(); err != nil {
-		return nil, fmt.Errorf("unable to refresh vcd token: [%v]", err)
 	}
 
 	vmUUID := strings.TrimPrefix(vcdVmUUID, VCDVMIDPrefix)

--- a/pkg/vcdclient/vms.go
+++ b/pkg/vcdclient/vms.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package vcdclient
@@ -79,7 +79,6 @@ func (client *Client) FindVMByUUID(vcdVmUUID string) (*govcd.VM, error) {
 
 	return vm, nil
 }
-
 
 // IsVmNotAvailable : In VCD, if the VM is not available, it can be an access error or the VM may not be present.
 // Hence we sometimes get an error different from govcd.ErrorEntityNotFound

--- a/release/version
+++ b/release/version
@@ -1,1 +1,1 @@
-0.1.0
+0.1.0.shamasundara

--- a/release/version
+++ b/release/version
@@ -1,1 +1,1 @@
-0.1.0.shamasundara
+0.1.0

--- a/testdata/config_test.yaml
+++ b/testdata/config_test.yaml
@@ -4,6 +4,7 @@ vcd:
   vdc: "org-vdc"
   user: "vmware-cloud-director-user"
   secret: "password-of-vmware-cloud-director-user"
+  refreshToken: "refresh-token"
   network: "network-used-in-org-vdc"
   vipSubnet: "subnet-CIDR-from-which-VirtualIPs-are-picked"
 loadbalancer:

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,6 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package version


### PR DESCRIPTION
This PR makes changes to exchange the refresh token provided at the initialization of CPI to get access token at all top level functions called by kubernetes

Testing done:
* checked if refresh token is being exchanged with access token at the top level function - InstanceExistsByProviderID

@arunmk @ltimothy7 