### PR TITLE
[VCDA-2577] Changes to use access token at all top level functions

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -56,6 +56,9 @@ func (lb *LBManager) getNodeIPs() ([]string, error) {
 func (lb *LBManager) EnsureLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
 
+	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
+		return
+	}
 	nodeIPs, err := lb.getNodeIPs()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get nodes in cluster: [%v]", err)
@@ -94,6 +97,9 @@ func (lb *LBManager) getLBPoolNamePrefix(serviceName string, clusterID string) s
 // Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager
 func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (err error) {
+	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
+		return
+	}
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(service.Name, lb.vcdClient.ClusterID)
 	nodeIps := lb.getNodeInternalIps(nodes)
 	klog.Infof("UpdateLoadBalancer Node Ips: %v", nodeIps)
@@ -119,6 +125,9 @@ func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 func (lb *LBManager) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string,
 	service *v1.Service) error {
 
+	if err := lb.vcdClient.RefreshBearerToken(); err != nil {
+		return err
+	}
 	return lb.deleteLoadBalancer(ctx, service)
 }
 
@@ -152,6 +161,9 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
 
+	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
+		return
+	}
 	return lb.getLoadBalancer(ctx, service)
 }
 

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -57,7 +57,7 @@ func (lb *LBManager) EnsureLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
 
 	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
-		return
+		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	nodeIPs, err := lb.getNodeIPs()
 	if err != nil {
@@ -98,7 +98,7 @@ func (lb *LBManager) getLBPoolNamePrefix(serviceName string, clusterID string) s
 func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service, nodes []*v1.Node) (err error) {
 	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
-		return
+		return fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(service.Name, lb.vcdClient.ClusterID)
 	nodeIps := lb.getNodeInternalIps(nodes)
@@ -126,7 +126,7 @@ func (lb *LBManager) EnsureLoadBalancerDeleted(ctx context.Context, clusterName 
 	service *v1.Service) error {
 
 	if err := lb.vcdClient.RefreshBearerToken(); err != nil {
-		return err
+		return fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	return lb.deleteLoadBalancer(ctx, service)
 }
@@ -162,7 +162,7 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 	service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
 
 	if err = lb.vcdClient.RefreshBearerToken(); err != nil {
-		return
+		return nil, false, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	return lb.getLoadBalancer(ctx, service)
 }

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -102,7 +102,7 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 
 	captureTime := time.Now()
 	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	vm, err := vmic.vcdClient.FindVMByName(vmName)
 	if err != nil {
@@ -145,7 +145,7 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 
 	captureTime := time.Now()
 	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 	vm, err := vmic.vcdClient.FindVMByUUID(vmUUID)
 	if err != nil {

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -101,6 +101,9 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 	}
 
 	captureTime := time.Now()
+	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
+		return nil, err
+	}
 	vm, err := vmic.vcdClient.FindVMByName(vmName)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
@@ -141,6 +144,9 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 	}
 
 	captureTime := time.Now()
+	if err := vmic.vcdClient.RefreshBearerToken(); err != nil {
+		return nil, err
+	}
 	vm, err := vmic.vcdClient.FindVMByUUID(vmUUID)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -44,14 +44,19 @@ type Client struct {
 }
 
 func (client *Client) RefreshBearerToken() error {
-	// No need to refresh token if logged in using username and password
+	href := fmt.Sprintf("%s/api", client.vcdAuthConfig.Host)
 	if client.vcdAuthConfig.User != "" && client.vcdAuthConfig.Password != "" && client.vcdAuthConfig.RefreshToken == "" {
+		resp, err := client.vcdClient.GetAuthResponse(client.vcdAuthConfig.User, client.vcdAuthConfig.Password, client.vcdAuthConfig.Org)
+		if err != nil {
+			return fmt.Errorf("unable to authenticate [%s/%s] for url [%s]: [%+v] : [%v]",
+				client.vcdAuthConfig.Org, client.vcdAuthConfig.User, href, resp, err)
+		}
 		return nil
 	}
 	client.vcdClient.Client.APIVersion = VCloudApiVersion
 	accessTokenResponse, _, err := client.vcdAuthConfig.getAccessTokenFromRefreshToken(client.vcdClient.Client.IsSysAdmin)
 	if err != nil {
-		return fmt.Errorf("failed to refresh access token: [%v]", err)
+		return fmt.Errorf("failed to get access token from refresh token for user [%s/%s] for url [%s]: [%v]", client.vcdAuthConfig.Org, client.vcdAuthConfig.User, href, err)
 	}
 	err = client.vcdClient.SetToken(client.vcdAuthConfig.Org, "Authorization", fmt.Sprintf("Bearer %s", accessTokenResponse.AccessToken))
 	if err != nil {

--- a/pkg/vcdclient/vms.go
+++ b/pkg/vcdclient/vms.go
@@ -23,10 +23,6 @@ func (client *Client) FindVMByName(vmName string) (*govcd.VM, error) {
 		return nil, fmt.Errorf("vmName mandatory for FindVMByName")
 	}
 
-	if err := client.RefreshToken(); err != nil {
-		return nil, fmt.Errorf("unable to refresh vcd token: [%v]", err)
-	}
-
 	// Query is be delimited to org where user exists. The expectation is that
 	// there will be exactly one VM with that name.
 	results, err := client.vdc.QueryWithNotEncodedParams(
@@ -63,10 +59,6 @@ func (client *Client) FindVMByName(vmName string) (*govcd.VM, error) {
 func (client *Client) FindVMByUUID(vcdVmUUID string) (*govcd.VM, error) {
 	if vcdVmUUID == "" {
 		return nil, fmt.Errorf("vmUUID mandatory for FindVMByUUID")
-	}
-
-	if err := client.RefreshToken(); err != nil {
-		return nil, fmt.Errorf("unable to refresh vcd token: [%v]", err)
 	}
 
 	vmUUID := strings.TrimPrefix(vcdVmUUID, VCDVMIDPrefix)


### PR DESCRIPTION
This PR makes changes to exchange the refresh token provided at the initialization of CPI to get access token at all top level functions called by kubernetes

Testing done:
* checked if refresh token is being exchanged with access token at the top level function - InstanceExistsByProviderID

@arunmk @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/16)
<!-- Reviewable:end -->
