### PR TITLE
manually set IsSysAdmin boolean while refreshing vcd client

### DIFF
--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -34,7 +34,7 @@ type VCDAuthConfig struct {
 	VDC          string `json:"vdc"`
 	Insecure     bool   `json:"insecure"`
 	Token        string `json:"token"`
-	IsSysAdmin   bool   `json:"isSysAdmin,omitempty"` // will be set by GetBearerToken()
+	IsSysAdmin   bool   // will be set by GetBearerToken()
 }
 
 func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response, error) {

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -34,6 +34,7 @@ type VCDAuthConfig struct {
 	VDC          string `json:"vdc"`
 	Insecure     bool   `json:"insecure"`
 	Token        string `json:"token"`
+	IsSysAdmin   bool   `json:"isSysAdmin,omitempty"` // will be set by GetBearerToken()
 }
 
 func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response, error) {
@@ -63,10 +64,11 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set authorization header: [%v]", err)
 		}
-		vcdClient.Client.IsSysAdmin, err = isAdminUser(vcdClient)
+		config.IsSysAdmin, err = isAdminUser(vcdClient)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to determine if the user is a system administrator: [%v]", err)
 		}
+		vcdClient.Client.IsSysAdmin = config.IsSysAdmin
 
 		klog.Infof("Running CPI as sysadmin [%v]", vcdClient.Client.IsSysAdmin)
 		return vcdClient, resp, nil


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

When refreshing client using refresh token, isSysadmin boolean for the client should be manually set to true to overwrite the changes made by goVcd during SetToken()

@arunmk @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/18)
<!-- Reviewable:end -->
