### PR TITLE
VCDA-2949: Ensure that loadbalancer creation retry will succeed

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -147,6 +147,10 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 					fmt.Errorf("unable to get virtual service summary for [%s]: [%v]",
 					virtualServiceName, err)
 			}
+			if virtualIP == "" {
+				// if any lb that is expected is not created, return false to retry creation
+				return nil, false, nil
+			}
 
 		case lb.vcdClient.HTTPSPort:
 			virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, "https")
@@ -155,6 +159,10 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 				return nil, false,
 					fmt.Errorf("unable to get virtual service summary for [%s]: [%v]",
 						virtualServiceName, err)
+			}
+			if virtualIP == "" {
+				// if any lb that is expected is not created, return false to retry creation
+				return nil, false, nil
 			}
 
 		default:


### PR DESCRIPTION
Get only prefix and loop through services to check if anything needs to be added. Hence even if http is the only service created, we'll mark the loadbalancer as incomplete and try to create the https service as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/20)
<!-- Reviewable:end -->
