### PR TITLE
VCDA-3113: Passing user/secret as part of secrets was broken.

### DIFF
--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -139,24 +139,13 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:0.1.0.latest
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director
             - --cloud-provider=vmware-cloud-director
             - --cloud-config=/etc/kubernetes/vcloud/vcloud-ccm-config.yaml
             - --allow-untagged-cloud=true
-          env:
-            - name: VCD_BASIC_AUTH_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: vcloud-basic-auth
-                  key: username
-            - name: VCD_BASIC_AUTH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: vcloud-basic-auth
-                  key: password
           volumeMounts:
             - name: vcloud-ccm-config-volume
               mountPath: /etc/kubernetes/vcloud

--- a/pkg/ccm/cloud.go
+++ b/pkg/ccm/cloud.go
@@ -48,7 +48,7 @@ func newVCDCloudProvider(configReader io.Reader) (cloudProvider.Interface, error
 	for {
 		err = config.SetAuthorization(cloudConfig)
 		if err != nil {
-			klog.Infof("unable to set authorization in config: [%v]", err)
+			klog.Infof("Unable to set authorization in config: [%v]", err)
 			time.Sleep(10 * time.Second)
 			continue
 		}

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -73,6 +73,7 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 		klog.Infof("Running CPI as sysadmin [%v]", vcdClient.Client.IsSysAdmin)
 		return vcdClient, resp, nil
 	}
+
 	resp, err = vcdClient.GetAuthResponse(config.User, config.Password, config.UserOrg)
 	if err != nil {
 		return nil, resp, fmt.Errorf("unable to authenticate [%s/%s] for url [%s]: [%+v] : [%v]",
@@ -86,7 +87,7 @@ func (config *VCDAuthConfig) GetSwaggerClientFromSecrets() (*govcd.VCDClient, *s
 
 	vcdClient, _, err := config.GetBearerToken()
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get bearer token from serets: [%v]", err)
+		return nil, nil, fmt.Errorf("unable to get bearer token from secrets: [%v]", err)
 	}
 	var authHeader string
 	if config.RefreshToken == "" {

--- a/release/version
+++ b/release/version
@@ -1,1 +1,1 @@
-0.1.0
+main-branch


### PR DESCRIPTION
They were being passed as secrets and also as VCD config. This
change removes passing as configmap and uses only secrets with
retries.

This change also changes version of main branch to main-branch
so that people can point to the latest unreleased tip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/32)
<!-- Reviewable:end -->
