### PR TITLE
VCDA-3151: fix regression with username/password and refreshToken

### DIFF
--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"io/ioutil"
 	"k8s.io/klog"
-	"os"
 	"strings"
 )
 
@@ -104,39 +103,46 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 }
 
 func SetAuthorization(config *CloudConfig) error {
-	// check if refresh token is present.
-	if _, err := os.Stat("/etc/kubernetes/vcloud/basic-auth/refreshToken"); err == nil {
-		// refresh token is present. Populate only refresh token and keep user and secret empty
-		refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
-		if err != nil {
-			return fmt.Errorf("unable to get refresh token: [%v]", err)
-		}
-
-		config.VCD.RefreshToken = string(refreshToken)
-		if config.VCD.RefreshToken != "" {
-			return nil
-		}
+	refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
+	if err != nil {
+		klog.Infof("Unable to get refresh token: [%v]", err)
+	} else {
+		config.VCD.RefreshToken = strings.TrimSuffix(string(refreshToken), "\n")
 	}
-	klog.Infof("Unable to get refresh token. Looking for username and password")
 
 	username, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
 	if err != nil {
-		return fmt.Errorf("unable to get username: [%v]", err)
+		klog.Infof("Unable to get username: [%v]", err)
+	} else {
+		trimmedUserName := strings.TrimSuffix(string(username), "\n")
+		if string(trimmedUserName) != "" {
+			config.VCD.UserOrg, config.VCD.User, err = getUserAndOrg(trimmedUserName, config.VCD.Org)
+			if err != nil {
+				return fmt.Errorf("unable to get user org and name: [%v]", err)
+			}
+		}
+	}
+	if config.VCD.UserOrg == "" {
+		config.VCD.UserOrg = strings.TrimSuffix(config.VCD.Org, "\n")
 	}
 
 	secret, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
 	if err != nil {
-		return fmt.Errorf("unable to get password: [%v]", err)
+		klog.Infof("Unable to get password: [%v]", err)
+	} else {
+		config.VCD.Secret = strings.TrimSuffix(string(secret), "\n")
 	}
 
-	config.VCD.UserOrg, config.VCD.User, err = getUserAndOrg(string(username), config.VCD.Org)
-	if err != nil {
-		return fmt.Errorf("unable to get user org and name: [%v]", err)
+	if config.VCD.RefreshToken != "" {
+		klog.Infof("Using non-empty refresh token.")
+		return nil
+	}
+	if config.VCD.User != "" && config.VCD.UserOrg != "" && config.VCD.Secret != "" {
+		klog.Infof("Using username/secret based credentials.")
+		return nil
 	}
 
-	config.VCD.Secret = string(secret)
-
-	return nil
+	return fmt.Errorf("unable to get valid set of credentials from secrets")
 }
 
 func ValidateCloudConfig(config *CloudConfig) error {


### PR DESCRIPTION
This was a fix locally on my machine.

Basically we read all parameters and try to find the UserOrg in case it is not specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/34)
<!-- Reviewable:end -->
