### PR TITLE
VCDA-3240: also handle nativeCluster

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -185,9 +185,16 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 }
 
 // getTrimmedClusterID: this is a mitigation to not overflow VCD name length limits. There is a clearer
-// fix needed in the future.
+// fix needed in the future. Cover all cluster prefixes.
 func (lb *LBManager) getTrimmedClusterID() string {
-	return strings.TrimPrefix(lb.vcdClient.ClusterID, "urn:vcloud:entity:vmware:")
+	clusterID := lb.vcdClient.ClusterID
+	for _, prefix := range []string{
+		"urn:vcloud:entity:vmware:",
+		"urn:vcloud:entity:cse:nativeCluster:",
+	} {
+		clusterID = strings.TrimPrefix(clusterID, prefix)
+	}
+	return clusterID
 }
 
 func (lb *LBManager) getLBPoolNamePrefix(_ context.Context, service *v1.Service) string {

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -893,7 +893,7 @@ func (client *Client) createVirtualService(ctx context.Context, virtualServiceNa
 	switch vsType {
 	case "TCP":
 		virtualServiceConfig.ApplicationProfile.Name = "System-L4-Application"
-		virtualServiceConfig.ApplicationProfile.Type_ = "TCP"
+		virtualServiceConfig.ApplicationProfile.Type_ = "L4"
 		if useSSL {
 			virtualServiceConfig.ApplicationProfile.Name = "System-SSL-Application"
 			virtualServiceConfig.ApplicationProfile.Type_ = "L4_TLS" // this needs Enterprise License


### PR DESCRIPTION
Some small regressions: support native clusters and use L4 for TCP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/42)
<!-- Reviewable:end -->
