### PR TITLE
Update Virtual Service, DNAT rule and App port profile on LB update

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -85,12 +85,14 @@ func (lb *LBManager) getNodeInternalIps(nodes []*v1.Node) []string {
 	return nodeIps
 }
 
-func (lb *LBManager) getServicePortMap(service *v1.Service) map[string]int32 {
+func (lb *LBManager) getServicePortMap(service *v1.Service) (map[string]int32, map[string]int32) {
 	typeToInternalPort := make(map[string]int32)
+	typeToExternalPort := make(map[string]int32)
 	for _, port := range service.Spec.Ports {
 		typeToInternalPort[strings.ToLower(port.Name)] = port.NodePort
+		typeToExternalPort[strings.ToLower(port.Name)] = port.Port
 	}
-	return typeToInternalPort
+	return typeToInternalPort, typeToExternalPort
 }
 
 // UpdateLoadBalancer updates hosts under the specified load balancer.
@@ -108,11 +110,14 @@ func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 	klog.Infof("UpdateLoadBalancer Node Ips: %v", nodeIps)
 
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
-	typeToInternalPortMap := lb.getServicePortMap(service)
+	virtualServiceNamePrefix := lb.getVirtualServicePrefix(ctx, service)
+	typeToInternalPortMap, typeToExternalPort := lb.getServicePortMap(service)
 	for portName, internalPort := range typeToInternalPortMap {
 		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portName)
+		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portName)
+		port := typeToExternalPort[portName]
 		klog.Infof("Updating pool [%s] with port [%s:%d]", lbPoolName, portName, internalPort)
-		if err := lb.vcdClient.UpdateLoadBalancer(ctx, lbPoolName, nodeIps, internalPort); err != nil {
+		if err := lb.vcdClient.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, nodeIps, internalPort, port); err != nil {
 			return fmt.Errorf("unable to update pool [%s] with port [%s:%d]: [%v]", lbPoolName, portName,
 				internalPort, err)
 		}
@@ -273,27 +278,27 @@ func getSSLCertAlias(service *v1.Service) string {
 func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service,
 	nodeIPs []string) (*v1.LoadBalancerStatus, error) {
 
+	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
+	virtualServiceNamePrefix := lb.getVirtualServicePrefix(ctx, service)
 	lbStatus, lbExists, err := lb.getLoadBalancer(ctx, service)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error while querying for loadbalancer: [%v]", err)
 	}
 	if lbExists {
 		// Update load balancer if there are changes in service properties
-		lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
-		typeToInternalPortMap := lb.getServicePortMap(service)
+		typeToInternalPortMap, typeToExternalPortMap := lb.getServicePortMap(service)
 		for portName, internalPort := range typeToInternalPortMap {
 			lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portName)
-			klog.Infof("Updating pool [%s] with port [%s:%d]", lbPoolName, portName, internalPort)
-			if err := lb.vcdClient.UpdateLoadBalancer(ctx, lbPoolName, nodeIPs, internalPort); err != nil {
-				return nil, fmt.Errorf("unable to update pool [%s] with port [%s:%d]: [%v]", lbPoolName, portName,
-					internalPort, err)
+			virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portName)
+			externalPort := typeToExternalPortMap[portName]
+			klog.Infof("Updating pool [%s] with port [%s:%d:%d]", lbPoolName, portName, internalPort, externalPort)
+			if err := lb.vcdClient.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, nodeIPs, internalPort, externalPort); err != nil {
+				return nil, fmt.Errorf("unable to update pool [%s] with port [%s:%d:%d]: [%v]", lbPoolName, portName,
+					internalPort, externalPort, err)
 			}
 		}
 		return lbStatus, nil
 	}
-
-	virtualServiceName := lb.getVirtualServicePrefix(ctx, service)
-	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
 
 	// While creating the lb, even if only one of http/https is remaining and the other is completed,
 	// ask for both to be created. The already created one will silently pass.
@@ -337,7 +342,7 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 	klog.Infof("Creating loadbalancer for ports [%#v]\n", portDetailsList)
 
 	// Create using VCD API
-	lbIP, err := lb.vcdClient.CreateLoadBalancer(ctx, virtualServiceName, lbPoolNamePrefix, nodeIPs, portDetailsList)
+	lbIP, err := lb.vcdClient.CreateLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, nodeIPs, portDetailsList)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create loadbalancer for ports [%#v]: [%v]", portDetailsList, err)
 	}

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -115,9 +115,9 @@ func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 	for portName, internalPort := range typeToInternalPortMap {
 		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portName)
 		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portName)
-		port := typeToExternalPort[portName]
+		externalPort := typeToExternalPort[portName]
 		klog.Infof("Updating pool [%s] with port [%s:%d]", lbPoolName, portName, internalPort)
-		if err := lb.vcdClient.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, nodeIps, internalPort, port); err != nil {
+		if err := lb.vcdClient.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, nodeIps, internalPort, externalPort); err != nil {
 			return fmt.Errorf("unable to update pool [%s] with port [%s:%d]: [%v]", lbPoolName, portName,
 				internalPort, err)
 		}

--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -6,8 +6,8 @@
 package vcdclient
 
 import (
-	"io/ioutil"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -110,5 +110,7 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 		"refreshToken": authDetails.SystemUserRefreshToken,
 		"userOrg": "system",
 	})
+	assert.NoError(t, err, "Unable to get VCD client for system administrator")
+	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 	return
 }

--- a/pkg/vcdclient/errors.go
+++ b/pkg/vcdclient/errors.go
@@ -6,6 +6,10 @@ type VirtualServicePendingError struct {
 	VirtualServiceName string
 }
 
+type LoadBalancerPoolBusyError struct {
+	LBPoolName string
+}
+
 func (vsError *VirtualServicePendingError) Error() string {
 	return fmt.Sprintf("virtual service [%s] is in Pending state", vsError.VirtualServiceName)
 }
@@ -13,5 +17,15 @@ func (vsError *VirtualServicePendingError) Error() string {
 func NewVirtualServicePendingError(virtualServiceName string) *VirtualServicePendingError {
 	return &VirtualServicePendingError{
 		VirtualServiceName: virtualServiceName,
+	}
+}
+
+func (lbPoolError *LoadBalancerPoolBusyError) Error() string {
+	return fmt.Sprintf("load balancer pool [%s] is busy", lbPoolError.LBPoolName)
+}
+
+func NewLBPoolBusyError(lbPoolName string) *LoadBalancerPoolBusyError {
+	return &LoadBalancerPoolBusyError{
+		LBPoolName: lbPoolName,
 	}
 }

--- a/pkg/vcdclient/errors.go
+++ b/pkg/vcdclient/errors.go
@@ -6,6 +6,10 @@ type VirtualServicePendingError struct {
 	VirtualServiceName string
 }
 
+type VirtualServiceBusyError struct {
+	VirtualServiceName string
+}
+
 type LoadBalancerPoolBusyError struct {
 	LBPoolName string
 }
@@ -16,6 +20,16 @@ func (vsError *VirtualServicePendingError) Error() string {
 
 func NewVirtualServicePendingError(virtualServiceName string) *VirtualServicePendingError {
 	return &VirtualServicePendingError{
+		VirtualServiceName: virtualServiceName,
+	}
+}
+
+func (vsError *VirtualServiceBusyError) Error() string {
+	return fmt.Sprintf("virtual service [%s] is busy", vsError.VirtualServiceName)
+}
+
+func NewVirtualServiceBusyError(virtualServiceName string) *VirtualServiceBusyError {
+	return &VirtualServiceBusyError{
 		VirtualServiceName: virtualServiceName,
 	}
 }

--- a/pkg/vcdclient/errors.go
+++ b/pkg/vcdclient/errors.go
@@ -14,6 +14,10 @@ type LoadBalancerPoolBusyError struct {
 	LBPoolName string
 }
 
+type GatewayBusyError struct {
+	GatewayName string
+}
+
 func (vsError *VirtualServicePendingError) Error() string {
 	return fmt.Sprintf("virtual service [%s] is in Pending state", vsError.VirtualServiceName)
 }
@@ -41,5 +45,15 @@ func (lbPoolError *LoadBalancerPoolBusyError) Error() string {
 func NewLBPoolBusyError(lbPoolName string) *LoadBalancerPoolBusyError {
 	return &LoadBalancerPoolBusyError{
 		LBPoolName: lbPoolName,
+	}
+}
+
+func (gatewayBusyError *GatewayBusyError) Error() string {
+	return fmt.Sprintf("gateway [%s] is busy", gatewayBusyError.GatewayName)
+}
+
+func NewGatewayBusyError(gatewayName string) *GatewayBusyError {
+	return &GatewayBusyError{
+		GatewayName: gatewayName,
 	}
 }

--- a/pkg/vcdclient/gateway_system_test.go
+++ b/pkg/vcdclient/gateway_system_test.go
@@ -457,36 +457,119 @@ func TestVirtualServiceHttpCRUDE(t *testing.T) {
 	require.NotNil(t, vsRef, "VirtualServiceRef should not be nil")
 	assert.Equal(t, virtualServiceName, vsRef.Name, "Virtual Service name should match")
 
-	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8080)
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8080)
+		if err != nil {
+			if _, ok := err.(*VirtualServiceBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("virtual service is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.NoError(t, err, "Unable to update external port")
 
 	// repeated update should not fail
-	// The sleep is needed because the below call fails if VCD is busy completing the previous update.
-	time.Sleep(5*time.Second)
-	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8080)
+	// update and delete calls might error out if virtual services are busy. Retry if the error is caused by the busy virtual services
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8080)
+		if err != nil {
+			if _, ok := err.(*VirtualServiceBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("virtual service is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.NoError(t, err, "Repeated update to external port should not fail")
 
-	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName+"-invalid", 8080)
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName+"-invalid", 8080)
+		if err != nil {
+			if _, ok := err.(*VirtualServiceBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("virtual service is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.Error(t, err, "Update virtual service on a non-existent virtual service should fail")
 
-	err = vcdClient.deleteVirtualService(ctx, virtualServiceName, true, externalIP)
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.deleteVirtualService(ctx, virtualServiceName, true, externalIP)
+		if err != nil {
+			if _, ok := err.(*VirtualServiceBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("virtual service is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.NoError(t, err, "Unable to delete Virtual Service")
 
 	rdeVips, _, _, err = vcdClient.GetRDEVirtualIps(ctx)
 	assert.NoError(t, err, "Unable to get vips from RDE after virtual service deletion")
 	assert.False(t, foundStringInSlice(externalIP, rdeVips), "external ip should not be found in RDE vips")
 
-	err = vcdClient.deleteVirtualService(ctx, virtualServiceName, true, externalIP)
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.deleteVirtualService(ctx, virtualServiceName, true, externalIP)
+		if err != nil {
+			if _, ok := err.(*VirtualServiceBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("virtual service is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.Error(t, err, "Should fail when deleting non-existing Virtual Service")
 
-	err = vcdClient.deleteVirtualService(ctx, virtualServiceName, false, externalIP)
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.deleteVirtualService(ctx, virtualServiceName, false, externalIP)
+		if err != nil {
+			if _, ok := err.(*VirtualServiceBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("virtual service is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.NoError(t, err, "Should not fail when deleting non-existing Virtual Service")
 
 	vsRefObtained, err = vcdClient.getVirtualService(ctx, virtualServiceName)
 	assert.NoError(t, err, "Get should not fail when Virtual Service is absent")
 	assert.Nil(t, vsRefObtained, "Deleted Virtual Service reference should be nil")
 
-	err = vcdClient.deleteLoadBalancerPool(ctx, lbPoolName, true)
+	for i := 0; i < BusyRetries ; i ++ {
+		err = vcdClient.deleteLoadBalancerPool(ctx, lbPoolName, true)
+		if err != nil {
+			if _, ok := err.(*LoadBalancerPoolBusyError); !ok {
+				break
+			}
+		} else {
+			break
+		}
+		// sleep for 2 seconds and retry
+		time.Sleep(2*time.Second)
+		fmt.Printf("loadbalancer pool is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
+	}
 	assert.NoError(t, err, "Should not fail when deleting lb pool")
 
 	return

--- a/pkg/vcdclient/gateway_system_test.go
+++ b/pkg/vcdclient/gateway_system_test.go
@@ -420,8 +420,6 @@ func TestVirtualServiceHttpsCRUDE(t *testing.T) {
 	assert.NoError(t, err, "Unable to update external port")
 
 	// repeated update should not fail
-	// The sleep is needed because the below call fails if VCD is busy completing the previous update.
-	time.Sleep(5*time.Second)
 	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8443)
 	assert.NoError(t, err, "Repeated update to external port should not fail")
 

--- a/pkg/vcdclient/gateway_system_test.go
+++ b/pkg/vcdclient/gateway_system_test.go
@@ -98,7 +98,7 @@ func TestDNATRuleCRUDE(t *testing.T) {
 
 	// update and delete calls might error out if the gateway is busy. Retry if the error is caused by the busy gateway
 	for i := 0; i < BusyRetries ; i ++ {
-		err = vcdClient.updateDNATRule(ctx, dnatRuleName, "2.3.4.5", "2.3.4.5", 8080, 30123)
+		err = vcdClient.updateDNATRule(ctx, dnatRuleName, "2.3.4.5", "2.3.4.5", 8080)
 		if err != nil {
 			if _, ok := err.(*GatewayBusyError); !ok {
 				break
@@ -113,7 +113,7 @@ func TestDNATRuleCRUDE(t *testing.T) {
 	assert.NoError(t, err, "Unable to update dnat rule")
 
 	for i := 0; i < BusyRetries ; i ++ {
-		err = vcdClient.updateDNATRule(ctx, dnatRuleName, "2.3.4.5", "2.3.4.5", 8080, 30123)
+		err = vcdClient.updateDNATRule(ctx, dnatRuleName, "2.3.4.5", "2.3.4.5", 8080)
 		if err != nil {
 			if _, ok := err.(*GatewayBusyError); !ok {
 				break

--- a/pkg/vcdclient/gateway_system_test.go
+++ b/pkg/vcdclient/gateway_system_test.go
@@ -8,8 +8,12 @@ package vcdclient
 import (
 	"context"
 	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +22,20 @@ import (
 
 func TestCacheGatewayDetails(t *testing.T) {
 
-	vcdClient, err := getTestVCDClient(nil)
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
+	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
+	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
@@ -43,7 +60,18 @@ func TestCacheGatewayDetails(t *testing.T) {
 
 func TestDNATRuleCRUDE(t *testing.T) {
 
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
 	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
 		"getVdcClient": true,
 	})
 	assert.NoError(t, err, "Unable to get VCD client")
@@ -83,7 +111,20 @@ func TestDNATRuleCRUDE(t *testing.T) {
 
 func TestLBPoolCRUDE(t *testing.T) {
 
-	vcdClient, err := getTestVCDClient(nil)
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
+	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
+	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
@@ -114,6 +155,14 @@ func TestLBPoolCRUDE(t *testing.T) {
 	assert.Equal(t, lbPoolRefUpdated.Name, lbPoolRef.Name, "LB Pool name should match")
 	assert.NotEmpty(t, lbPoolRefUpdated.Id, "LB Pool ID should not be empty")
 
+	// repeated update should work
+	lbPoolRefUpdated, err = vcdClient.updateLoadBalancerPool(ctx, lbPoolName, updatedIps, 55555)
+	assert.NoError(t, err, "No lbPool ref for updated lbPool on repeated update")
+	require.NotNil(t, lbPoolRefUpdated, "LB Pool reference should not be nil on repeated update")
+	assert.Equal(t, lbPoolRefUpdated.Name, lbPoolRef.Name, "LB Pool name should match on repeated update")
+	assert.NotEmpty(t, lbPoolRefUpdated.Id, "LB Pool ID should not be empty on repeated update")
+
+
 	lbPoolSummaryUpdated, err := vcdClient.getLoadBalancerPoolSummary(ctx, lbPoolName)
 	assert.NoError(t, err, "No LB Pool summary for updated pool.")
 	require.NotNil(t, lbPoolSummaryUpdated, "LB Pool summary reference should not be nil")
@@ -141,7 +190,20 @@ func TestLBPoolCRUDE(t *testing.T) {
 
 func TestGetLoadBalancerSEG(t *testing.T) {
 
-	vcdClient, err := getTestVCDClient(nil)
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
+	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
+	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
@@ -158,7 +220,19 @@ func TestGetLoadBalancerSEG(t *testing.T) {
 
 func TestGetUnusedGatewayIP(t *testing.T) {
 
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
 	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
 		"subnet": "",
 	})
 	assert.NoError(t, err, "Unable to get VCD client")
@@ -186,7 +260,20 @@ func TestGetUnusedGatewayIP(t *testing.T) {
 
 func TestVirtualServiceHttpCRUDE(t *testing.T) {
 
-	vcdClient, err := getTestVCDClient(nil)
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
+	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
+	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
@@ -226,6 +313,18 @@ func TestVirtualServiceHttpCRUDE(t *testing.T) {
 	require.NotNil(t, vsRef, "VirtualServiceRef should not be nil")
 	assert.Equal(t, virtualServiceName, vsRef.Name, "Virtual Service name should match")
 
+	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8080)
+	assert.NoError(t, err, "Unable to update external port")
+
+	// repeated update should not fail
+	// The sleep is needed because the below call fails if VCD is busy completing the previous update.
+	time.Sleep(5*time.Second)
+	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8080)
+	assert.NoError(t, err, "Repeated update to external port should not fail")
+
+	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName+"-invalid", 8080)
+	assert.Error(t, err, "Update virtual service on a non-existent virtual service should fail")
+
 	err = vcdClient.deleteVirtualService(ctx, virtualServiceName, true, externalIP)
 	assert.NoError(t, err, "Unable to delete Virtual Service")
 
@@ -260,7 +359,20 @@ func foundStringInSlice(find string, slice []string) bool {
 
 func TestVirtualServiceHttpsCRUDE(t *testing.T) {
 
-	vcdClient, err := getTestVCDClient(nil)
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
+	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
+	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
@@ -276,7 +388,10 @@ func TestVirtualServiceHttpsCRUDE(t *testing.T) {
 	externalIP := "11.12.13.14"
 	internalIP := "3.4.5.6"
 	virtualServiceName := fmt.Sprintf("test-virtual-service-https-%s", uuid.New().String())
-	certName := fmt.Sprintf("%s-cert", vcdClient.ClusterID)
+	certName := vcdClient.CertificateAlias
+	if certName == "" {
+		certName = fmt.Sprintf("%s-cert", vcdClient.ClusterID)
+	}
 	vsRef, err := vcdClient.createVirtualService(ctx, virtualServiceName, lbPoolRef, segRef,
 		internalIP, externalIP, "HTTPS", 443, true, certName)
 	assert.NoError(t, err, "Unable to create virtual service")
@@ -300,6 +415,18 @@ func TestVirtualServiceHttpsCRUDE(t *testing.T) {
 	assert.NoError(t, err, "Unable to create virtual service for the second time")
 	require.NotNil(t, vsRef, "VirtualServiceRef should not be nil")
 	assert.Equal(t, virtualServiceName, vsRef.Name, "Virtual Service name should match")
+
+	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8443)
+	assert.NoError(t, err, "Unable to update external port")
+
+	// repeated update should not fail
+	// The sleep is needed because the below call fails if VCD is busy completing the previous update.
+	time.Sleep(5*time.Second)
+	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName, 8443)
+	assert.NoError(t, err, "Repeated update to external port should not fail")
+
+	err = vcdClient.updateVirtualServicePort(ctx, virtualServiceName+"-invalid", 8443)
+	assert.Error(t, err, "Update virtual service on a non-existent virtual service should fail")
 
 	err = vcdClient.deleteVirtualService(ctx, virtualServiceName, true, externalIP)
 	assert.NoError(t, err, "Unable to delete Virtual Service")
@@ -326,7 +453,20 @@ func TestVirtualServiceHttpsCRUDE(t *testing.T) {
 
 func TestLoadBalancerCRUDE(t *testing.T) {
 
-	vcdClient, err := getTestVCDClient(nil)
+	authFile := filepath.Join(gitRoot, "testdata/auth_test.yaml")
+	authFileContent, err := ioutil.ReadFile(authFile)
+	assert.NoError(t, err, "There should be no error reading the auth file contents.")
+
+	var authDetails authorizationDetails
+	err = yaml.Unmarshal(authFileContent, &authDetails)
+	assert.NoError(t, err, "There should be no error parsing auth file content.")
+
+	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+		"getVdcClient": true,
+	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
@@ -334,16 +474,25 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 
 	virtualServiceNamePrefix := fmt.Sprintf("test-virtual-service-https-%s", uuid.New().String())
 	lbPoolNamePrefix := fmt.Sprintf("test-lb-pool-%s", uuid.New().String())
+	certName := vcdClient.CertificateAlias
+	if certName == "" {
+		certName = fmt.Sprintf("%s-cert", vcdClient.ClusterID)
+	}
 	portDetailsList := []PortDetails{
 		{
 			PortSuffix: `http`,
 			ExternalPort: 80,
 			InternalPort: 31234,
+			Protocol: "HTTP",
+			UseSSL: false,
 		},
 		{
 			PortSuffix: `https`,
 			ExternalPort: 443,
 			InternalPort: 31235,
+			Protocol: "HTTPS",
+			UseSSL: true,
+			CertAlias: certName,
 		},
 	}
 	freeIP, err := vcdClient.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
@@ -368,9 +517,24 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 
 	updatedIps := []string{"5.5.5.5"}
 	updatedInternalPort := int32(55555)
-	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", updatedIps, updatedInternalPort)
+	// update IPs and internal port
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, updatedInternalPort, 80)
 	assert.NoError(t, err, "HTTP Load Balancer should be updated")
-	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", updatedIps, updatedInternalPort)
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", virtualServiceNamePrefix+"-https", updatedIps, updatedInternalPort, 443)
+	assert.NoError(t, err, "HTTPS Load Balancer should be updated")
+
+	// update external port only
+	updatedExternalPortHttp := int32(8080)
+	updatedExternalPortHttps := int32(8443)
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, updatedInternalPort, updatedExternalPortHttp)
+	assert.NoError(t, err, "HTTP Load Balancer should be updated")
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", virtualServiceNamePrefix+"-https", updatedIps, updatedInternalPort, updatedExternalPortHttps)
+	assert.NoError(t, err, "HTTPS Load Balancer should be updated")
+
+	// No error on repeated update
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, updatedInternalPort, updatedExternalPortHttp)
+	assert.NoError(t, err, "HTTP Load Balancer should be updated")
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", virtualServiceNamePrefix+"-https", updatedIps, updatedInternalPort, updatedExternalPortHttps)
 	assert.NoError(t, err, "HTTPS Load Balancer should be updated")
 
 	err = vcdClient.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList)
@@ -387,9 +551,9 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 	err = vcdClient.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList)
 	assert.NoError(t, err, "Repeated deletion of Load Balancer should not fail")
 
-	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", updatedIps, updatedInternalPort)
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, updatedInternalPort, 80)
 	assert.Error(t, err, "updating deleted HTTP Load Balancer should be an error")
-	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", updatedIps, updatedInternalPort)
+	err = vcdClient.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", virtualServiceNamePrefix+"https", updatedIps, updatedInternalPort, 43)
 	assert.Error(t, err, "updating deleted HTTPS Load Balancer should be an error")
 
 	return

--- a/pkg/vcdclient/gateway_system_test.go
+++ b/pkg/vcdclient/gateway_system_test.go
@@ -253,7 +253,7 @@ func TestLBPoolCRUDE(t *testing.T) {
 		time.Sleep(2*time.Second)
 		fmt.Printf("load balancer pool is busy. remaining retry attempts: [%d]\n", BusyRetries- i - 1)
 	}
-	assert.NoError(t, err, "No lbPool ref for updated lbPool on repeated update")
+	assert.NoError(t, err, "There should be no error on repeated LB pool update")
 	require.NotNil(t, lbPoolRefUpdated, "LB Pool reference should not be nil on repeated update")
 	assert.Equal(t, lbPoolRefUpdated.Name, lbPoolRef.Name, "LB Pool name should match on repeated update")
 	assert.NotEmpty(t, lbPoolRefUpdated.Id, "LB Pool ID should not be empty on repeated update")


### PR DESCRIPTION
This PR addresses the issue https://github.com/vmware/cloud-provider-for-cloud-director/issues/49 by updating some load balancer components like Virtual Service and Application Port Profile on update to `port` in LoadBalancer in Kubernetes

* Virtual Service Port should be updated whenever LoadBalancer's Port is changed
* Updating the LoadBalancer Port value triggers an EnsureLoadBalancer event
* EnsureLoadBalancer should in turn call Update loadbalancer
* Make sure that repeated updates with the same value doesn't make API calls as repeated PUT with the same values will fail


Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/51)
<!-- Reviewable:end -->
