### PR TITLE
[VCDA-3448] Avoid updates to the DNAT rule if no chnage

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -10,15 +10,14 @@ package ccm
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdclient"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	cloudProvider "k8s.io/cloud-provider"
 	"k8s.io/klog"
+	"strconv"
+	"strings"
 )
 
 const (

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -530,6 +530,10 @@ func (client *Client) updateAppPortProfile(appPortProfileName string, externalPo
 	if appPortProfile == nil || appPortProfile.NsxtAppPortProfile == nil || len(appPortProfile.NsxtAppPortProfile.ApplicationPorts) == 0 || len(appPortProfile.NsxtAppPortProfile.ApplicationPorts[0].DestinationPorts) == 0  {
 		return fmt.Errorf("invalid app port profile [%s]", appPortProfileName)
 	}
+	if appPortProfile.NsxtAppPortProfile.ApplicationPorts[0].DestinationPorts[0] == fmt.Sprintf("%d", externalPort) {
+		klog.Infof("Update to application port profile [%s] is not required", appPortProfileName)
+		return nil
+	}
 	appPortProfile.NsxtAppPortProfile.ApplicationPorts[0].DestinationPorts[0] = fmt.Sprintf("%d", externalPort)
 	_, err = appPortProfile.Update(appPortProfile.NsxtAppPortProfile)
 	if err != nil {
@@ -568,7 +572,7 @@ func (client *Client) updateDNATRule(ctx context.Context, dnatRuleName string, e
 		return fmt.Errorf("failed to get DNAT rule with ID [%s] from gateway with ID [%s]; unexpected status code [%d]. Expected status code: [%d]", dnatRuleRef.ID, client.gatewayRef.Id, resp.StatusCode, http.StatusOK)
 	}
 	if dnatRule.ExternalAddresses == externalIP && dnatRule.InternalAddresses == internalIP && dnatRule.DnatExternalPort == strconv.FormatInt(int64(externalPort), 10) {
-		klog.Infof("No need to update DNAT rule [%s]", dnatRuleRef.Name)
+		klog.Infof("Update to DNAT rule [%s] not required", dnatRuleRef.Name)
 		return nil
 	}
 	// update DNAT rule


### PR DESCRIPTION
* Updates to DNAT rule may put the gateway in a busy state
* This may cause successive updates to fail
* Fix the above issue by not making an update call if the DNAT rule has not been changed

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/56)
<!-- Reviewable:end -->
