### PR TITLE
[VCDA-3443] Set authentication as system org user before falling back to userorg

### DIFF
--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -55,13 +55,22 @@ func (client *Client) RefreshBearerToken() error {
 	href := fmt.Sprintf("%s/api", client.VCDAuthConfig.Host)
 	client.VCDClient.Client.APIVersion = VCloudApiVersion
 
-	klog.Infof("Is user sysadmin: [%v]", client.VCDClient.Client.IsSysAdmin)
+	klog.Infof("Is user sysadmin: [%v]", client.VCDAuthConfig.IsSysAdmin)
 	if client.VCDAuthConfig.RefreshToken != "" {
-		// Refresh vcd client using refresh token
-		err := client.VCDClient.SetToken(client.VCDAuthConfig.UserOrg,
-			govcd.ApiTokenHeader, client.VCDAuthConfig.RefreshToken)
-		if err != nil {
-			return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
+		if client.VCDAuthConfig.IsSysAdmin {
+			// Refresh vcd client using refresh token as system org user
+			err := client.VCDClient.SetToken("system",
+				govcd.ApiTokenHeader, client.VCDAuthConfig.RefreshToken)
+			if err != nil {
+				return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
+			}
+		} else {
+			// Refresh vcd client using refresh token as tenant org user
+			err := client.VCDClient.SetToken(client.VCDAuthConfig.UserOrg,
+				govcd.ApiTokenHeader, client.VCDAuthConfig.RefreshToken)
+			if err != nil {
+				return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
+			}
 		}
 	} else if client.VCDAuthConfig.User != "" && client.VCDAuthConfig.Password != "" {
 		// Refresh vcd client using username and password

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -57,20 +57,15 @@ func (client *Client) RefreshBearerToken() error {
 
 	klog.Infof("Is user sysadmin: [%v]", client.VCDAuthConfig.IsSysAdmin)
 	if client.VCDAuthConfig.RefreshToken != "" {
+		userOrg := client.VCDAuthConfig.UserOrg
 		if client.VCDAuthConfig.IsSysAdmin {
-			// Refresh vcd client using refresh token as system org user
-			err := client.VCDClient.SetToken("system",
-				govcd.ApiTokenHeader, client.VCDAuthConfig.RefreshToken)
-			if err != nil {
-				return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
-			}
-		} else {
-			// Refresh vcd client using refresh token as tenant org user
-			err := client.VCDClient.SetToken(client.VCDAuthConfig.UserOrg,
-				govcd.ApiTokenHeader, client.VCDAuthConfig.RefreshToken)
-			if err != nil {
-				return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
-			}
+			userOrg = "system"
+		}
+		// Refresh vcd client using refresh token as system org user
+		err := client.VCDClient.SetToken(userOrg,
+			govcd.ApiTokenHeader, client.VCDAuthConfig.RefreshToken)
+		if err != nil {
+			return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
 		}
 	} else if client.VCDAuthConfig.User != "" && client.VCDAuthConfig.Password != "" {
 		// Refresh vcd client using username and password


### PR DESCRIPTION
* Address issue with system administrator login using refresh token
* Try authenticating to system org and fall back to user org if it fails
Testing done:
* ran system tests
* Executed CPI as system admin and org admin
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/57)
<!-- Reviewable:end -->
