### PR TITLE
[VCDA-3443] Set authentication as system org before falling back to userOrg

### DIFF
--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -6,8 +6,8 @@
 package vcdclient
 
 import (
-	"io/ioutil"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -110,5 +110,7 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 		"refreshToken": authDetails.SystemUserRefreshToken,
 		"userOrg": "system",
 	})
+	assert.NoError(t, err, "Unable to get VCD client for system administrator")
+	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 	return
 }

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -55,10 +55,14 @@ func (client *Client) RefreshBearerToken() error {
 	href := fmt.Sprintf("%s/api", client.vcdAuthConfig.Host)
 	client.vcdClient.Client.APIVersion = VCloudApiVersion
 
-	klog.Infof("Is user sysadmin: [%v]", client.vcdClient.Client.IsSysAdmin)
+	klog.Infof("Is user sysadmin: [%v]", client.vcdAuthConfig.IsSysAdmin)
 	if client.vcdAuthConfig.RefreshToken != "" {
-		// Refresh vcd client using refresh token
-		err := client.vcdClient.SetToken(client.vcdAuthConfig.UserOrg,
+		userOrg := client.vcdAuthConfig.UserOrg
+		if client.vcdAuthConfig.IsSysAdmin {
+			userOrg = "system"
+		}
+		// Refresh vcd client using refresh token as system org user
+		err := client.vcdClient.SetToken(userOrg,
 			govcd.ApiTokenHeader, client.vcdAuthConfig.RefreshToken)
 		if err != nil {
 			return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)


### PR DESCRIPTION
* Address issue with system administrator login using refresh token
* Try authenticating to system org and fall back to user org if it fails

Testing done:
* ran system tests
* Executed CPI as system admin and org admin
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/58)
<!-- Reviewable:end -->
