### PR TITLE
[VCDA-3513] Handle trailing slashes to avoid broken API paths

### DIFF
--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -98,12 +98,8 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 	if err = decoder.Decode(&config); err != nil {
 		return nil, fmt.Errorf("unable to decode yaml file: [%v]", err)
 	}
-	trimSlashFromHost(config)
+	config.VCD.Host = strings.TrimRight(config.VCD.Host, "/")
 	return config, nil
-}
-
-func trimSlashFromHost(cloudConfig *CloudConfig) {
-	cloudConfig.VCD.Host = strings.TrimRight(cloudConfig.VCD.Host, "/")
 }
 
 func SetAuthorization(config *CloudConfig) error {

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -16,10 +16,10 @@ import (
 
 // VCDConfig :
 type VCDConfig struct {
-	Host string `yaml:"host"`
-	VDC  string `yaml:"vdc"`
-	Org  string `yaml:"org"`
-	UserOrg      string // this defaults to Org or a prefix of User
+	Host    string `yaml:"host"`
+	VDC     string `yaml:"vdc"`
+	Org     string `yaml:"org"`
+	UserOrg string // this defaults to Org or a prefix of User
 
 	// It is allowed to pass the following variables using the config. However,
 	// that is unsafe security practice. However there can be user scenarios and
@@ -35,7 +35,7 @@ type VCDConfig struct {
 
 	VDCNetwork string `yaml:"network"`
 	VIPSubnet  string `yaml:"vipSubnet"`
-	VAppName  string  `yaml:"vAppName"`
+	VAppName   string `yaml:"vAppName"`
 }
 
 // Ports :
@@ -98,8 +98,12 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 	if err = decoder.Decode(&config); err != nil {
 		return nil, fmt.Errorf("unable to decode yaml file: [%v]", err)
 	}
-
+	trimSlashFromHost(config)
 	return config, nil
+}
+
+func trimSlashFromHost(cloudConfig *CloudConfig) {
+	cloudConfig.VCD.Host = strings.TrimRight(cloudConfig.VCD.Host, "/")
 }
 
 func SetAuthorization(config *CloudConfig) error {


### PR DESCRIPTION
Ticket: VCDA-3513

- Updated cloudConfig to trim trailing slashes from host after parsing the config
- Testing Done:
    - Created a cluster with host and trailing slash, resulting in coredns and csi pods to be stuck at pending state due
    - Locally built CSI/CPI images with removed slashes and updated the pods and deployment and brought them back up to a running state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/63)
<!-- Reviewable:end -->
