### PR TITLE
Remove code that makes NewClientFromSecrets() return a singleton

### DIFF
--- a/pkg/vcdsdk/client.go
+++ b/pkg/vcdsdk/client.go
@@ -17,10 +17,6 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
-var (
-	clientCreatorLock sync.Mutex
-)
-
 // Client :
 type Client struct {
 	VCDAuthConfig   *VCDAuthConfig // s
@@ -112,13 +108,9 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 
 	// TODO: Remove pkg/config dependency from vcdsdk; currently common_system_test.go depends on pkg/config
 	newUserOrg, newUsername, err := config.GetUserAndOrg(user, orgName, userOrg)
-
 	if err != nil {
 		return nil, fmt.Errorf("error parsing username before authenticating to VCD: [%v]", err)
 	}
-
-	clientCreatorLock.Lock()
-	defer clientCreatorLock.Unlock()
 
 	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, user, password, refreshToken, userOrg, insecure) //
 

--- a/pkg/vcdsdk/client.go
+++ b/pkg/vcdsdk/client.go
@@ -19,7 +19,6 @@ import (
 
 var (
 	clientCreatorLock sync.Mutex
-	clientSingleton   *Client = nil
 )
 
 // Client :
@@ -121,22 +120,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 	clientCreatorLock.Lock()
 	defer clientCreatorLock.Unlock()
 
-	// Return old client if everything matches. Else create new one and cache it.
-	// This is suboptimal but is not a common case.
-	if clientSingleton != nil {
-		if clientSingleton.VCDAuthConfig.Host == host &&
-			clientSingleton.ClusterOrgName == orgName &&
-			clientSingleton.ClusterOVDCName == vdcName &&
-			clientSingleton.VCDAuthConfig.UserOrg == newUserOrg &&
-			clientSingleton.VCDAuthConfig.User == newUsername &&
-			clientSingleton.VCDAuthConfig.Password == password &&
-			clientSingleton.VCDAuthConfig.RefreshToken == refreshToken &&
-			clientSingleton.VCDAuthConfig.Insecure == insecure {
-			return clientSingleton, nil
-		}
-	}
-
-	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, newUsername, password, refreshToken, newUserOrg, insecure) //
+	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, user, password, refreshToken, userOrg, insecure) //
 
 	vcdClient, apiClient, err := vcdAuthConfig.GetSwaggerClientFromSecrets()
 	if err != nil {
@@ -163,8 +147,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 		}
 	}
 	client.VCDClient = vcdClient
-	clientSingleton = client
 
-	klog.Infof("Client singleton is sysadmin: [%v]", clientSingleton.VCDClient.Client.IsSysAdmin)
-	return clientSingleton, nil
+	klog.Infof("Client is sysadmin: [%v]", client.VCDClient.Client.IsSysAdmin)
+	return client, nil
 }

--- a/pkg/vcdsdk/common_system_test.go
+++ b/pkg/vcdsdk/common_system_test.go
@@ -65,22 +65,6 @@ func getBoolValStrict(val interface{}, defaultVal bool) bool {
 	return defaultVal
 }
 
-//func getOneArmValStrict(val interface{}, defaultVal *config.OneArm) *config.OneArm {
-//	if oneArmVal, ok := val.(*config.OneArm); ok {
-//		return oneArmVal
-//	}
-//
-//	return defaultVal
-//}
-//
-//func getInt32ValStrict(val interface{}, defaultVal int32) int32 {
-//	if int32Val, ok := val.(int32); ok {
-//		return int32Val
-//	}
-//
-//	return defaultVal
-//}
-
 // config will be passed in from getTestConfig() and error checked in unit test
 func GetTestVCDClient(config *config.CloudConfig, inputMap map[string]interface{}) (*Client, error) {
 	cloudConfig := *config // Make a copy of cloudConfig so modified inputs don't carry over to next test


### PR DESCRIPTION
* NewVCDClientFromSecrets() used to return a singleton client on every call.
* Singleton client will cause issues in CAPVCD and it is not really used in the code.
* This PR removes the singleton client

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/71)
<!-- Reviewable:end -->
