### PR TITLE
Return virtual service summary if virtual service is pending

### DIFF
--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1199,7 +1199,6 @@ func (gatewayManager *GatewayManager) UpdateVirtualServicePort(ctx context.Conte
 	}, nil
 }
 
-// TODO: separate out rde operations: how?
 func (gatewayManager *GatewayManager) CreateVirtualService(ctx context.Context, virtualServiceName string,
 	lbPoolRef *swaggerClient.EntityReference, segRef *swaggerClient.EntityReference,
 	freeIP string, vsType string, externalPort int32,
@@ -1332,13 +1331,13 @@ func (gatewayManager *GatewayManager) CreateVirtualService(ctx context.Context, 
 			virtualServiceName, err)
 	}
 
-	if err = gatewayManager.CheckIfVirtualServiceIsPending(ctx, virtualServiceName); err != nil {
-		return nil, err
-	}
-
 	virtualServiceRef := &swaggerClient.EntityReference{
 		Name: vsSummary.Name,
 		Id:   vsSummary.Id,
+	}
+
+	if err = gatewayManager.CheckIfVirtualServiceIsPending(ctx, virtualServiceName); err != nil {
+		return virtualServiceRef, err
 	}
 
 	klog.Infof("Created virtual service [%v] on gateway [%v]\n", virtualServiceRef, gatewayManager.GatewayRef.Name)


### PR DESCRIPTION
* Create virtual service should return the virtual service summary if the virtual service is still pending. This will ensure we can still use the returned virtual service if we want to.
* Add virtual service to VCDResourceSet just after Virtual service creation  even if Virtual service goes to pending state
* Necessary to update Virtual service in the vcdResourceSet during CAPVCD reconciliation.

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/81)
<!-- Reviewable:end -->
