### PR TITLE
[VCDA-3471] Update RDE.status.CPI.errors and events

### DIFF
--- a/pkg/ccm/cloud.go
+++ b/pkg/ccm/cloud.go
@@ -84,11 +84,6 @@ func newVCDCloudProvider(configReader io.Reader) (cloudProvider.Interface, error
 
 	rdeManager := vcdsdk.NewRDEManager(vcdClient, cloudConfig.ClusterID, release.CloudControllerManagerName, release.CpiVersion)
 	cpiRdeManager := cpisdk.NewCPIRDEManager(rdeManager)
-	err = cpisdk.AddToEventSet(context.Background(), cpiRdeManager, cpisdk.ClientAuthenticated, cloudConfig.ClusterID,
-		fmt.Sprintf("client successfully authenticated as [%s] @ org [%s]", cloudConfig.VCD.User, cloudConfig.VCD.UserOrg))
-	if err != nil {
-		klog.Errorf("failed to add CPI event [%s] to EventSet in RDE [%s], [%v]", cpisdk.ClientAuthenticated, cloudConfig.ClusterID, err)
-	}
 
 	// setup LB only if the gateway is not NSX-T
 	var lb cloudProvider.LoadBalancer = nil

--- a/pkg/cpisdk/cpi_gateway_manager.go
+++ b/pkg/cpisdk/cpi_gateway_manager.go
@@ -77,7 +77,7 @@ func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualSer
 		ips, portDetailsList, oneArm, resourceAllocationMap)
 
 	if err != nil {
-		addToErrorSetErr := addToErrorSet(ctx, cpiRdeManager, CreateLoadbalancerError, cgm.ClusterID, err.Error())
+		addToErrorSetErr := AddToErrorSet(ctx, cpiRdeManager, CreateLoadbalancerError, cgm.ClusterID, err.Error())
 		if addToErrorSetErr != nil {
 			klog.Errorf("error adding CPI error to RDE: [%s], [%v]", cgm.ClusterID, addToErrorSetErr)
 		}
@@ -92,7 +92,7 @@ func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualSer
 		// We can record this error so users can know that the RDE may not contain the external IP even though it exists
 		err = cpiRdeManager.addVirtualIpToRDE(ctx, externalIP)
 		if err != nil {
-			addToErrorSetErr := addToErrorSet(ctx, cpiRdeManager, AddVIPToRdeError, cgm.ClusterID, err.Error())
+			addToErrorSetErr := AddToErrorSet(ctx, cpiRdeManager, AddVIPToRdeError, cgm.ClusterID, err.Error())
 			if addToErrorSetErr != nil {
 				klog.Errorf("error adding CPI error to RDE: [%s], [%v]", cgm.ClusterID, addToErrorSetErr)
 			}
@@ -106,7 +106,7 @@ func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualSer
 		klog.Errorf("there was an error removing CPI error [%s] from RDE [%s], [%v]", CreateLoadbalancerError, cgm.ClusterID, err)
 	}
 
-	err = addToEventSet(ctx, cpiRdeManager, CreatedLoadbalancer, cgm.ClusterID, fmt.Sprintf("Created loadbalancer successfully for [%s] with external IP: [%s]", cgm.ClusterID, externalIP))
+	err = AddToEventSet(ctx, cpiRdeManager, CreatedLoadbalancer, cgm.ClusterID, fmt.Sprintf("Created loadbalancer successfully for [%s] with external IP: [%s]", cgm.ClusterID, externalIP))
 	if err != nil {
 		klog.Errorf("error adding CPI event to RDE: [%v]", err)
 	}
@@ -130,7 +130,7 @@ func (cgm *CpiGatewayManager) UpdateLoadBalancer(ctx context.Context, lbPoolName
 	cpiRdeManager := NewCPIRDEManager(vcdsdkRdeManager)
 
 	if err := gm.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, ips, internalPort, externalPort); err != nil {
-		addToErrorSetErr := addToErrorSet(ctx, cpiRdeManager, UpdateLoadbalancerError, virtualServiceName, err.Error())
+		addToErrorSetErr := AddToErrorSet(ctx, cpiRdeManager, UpdateLoadbalancerError, virtualServiceName, err.Error())
 		if addToErrorSetErr != nil {
 			klog.Errorf("error adding CPI error to RDE: [%s], [%v]", cgm.ClusterID, addToErrorSetErr)
 		}
@@ -144,7 +144,7 @@ func (cgm *CpiGatewayManager) UpdateLoadBalancer(ctx context.Context, lbPoolName
 		klog.Errorf("there was an error removing CPI error [%s] from RDE [%s], [%v]", UpdateLoadbalancerError, cgm.ClusterID, err)
 	}
 
-	err = addToEventSet(ctx, cpiRdeManager, UpdatedLoadbalancer, virtualServiceName, fmt.Sprintf("Successfully updated loadbalancer with virtual service name [%s]: ", virtualServiceName))
+	err = AddToEventSet(ctx, cpiRdeManager, UpdatedLoadbalancer, virtualServiceName, fmt.Sprintf("Successfully updated loadbalancer with virtual service name [%s]: ", virtualServiceName))
 	if err != nil {
 		klog.Errorf("error adding CPI event to RDE: [%s], [%v]", cgm.ClusterID, err)
 	}
@@ -164,7 +164,7 @@ func (cgm *CpiGatewayManager) DeleteLoadBalancer(ctx context.Context, virtualSer
 
 	rdeVIP, err := gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm)
 	if err != nil {
-		addToErrorSetErr := addToErrorSet(ctx, cpiRdeManager, DeleteLoadbalancerError, cgm.ClusterID, err.Error())
+		addToErrorSetErr := AddToErrorSet(ctx, cpiRdeManager, DeleteLoadbalancerError, cgm.ClusterID, err.Error())
 		if addToErrorSetErr != nil {
 			klog.Errorf("error adding CPI error to RDE: [%v]", addToErrorSetErr)
 		}
@@ -176,7 +176,7 @@ func (cgm *CpiGatewayManager) DeleteLoadBalancer(ctx context.Context, virtualSer
 
 	err = cpiRdeManager.removeVirtualIpFromRDE(ctx, rdeVIP)
 	if err != nil {
-		addToErrorSetErr := addToErrorSet(ctx, cpiRdeManager, RemoveVIPFromRdeError, cgm.ClusterID, err.Error())
+		addToErrorSetErr := AddToErrorSet(ctx, cpiRdeManager, RemoveVIPFromRdeError, cgm.ClusterID, err.Error())
 		if addToErrorSetErr != nil {
 			klog.Errorf("unable to add CPI error to RDE: [%s], [%v]", cgm.ClusterID, addToErrorSetErr)
 		}
@@ -189,7 +189,7 @@ func (cgm *CpiGatewayManager) DeleteLoadBalancer(ctx context.Context, virtualSer
 		klog.Errorf("there was an error removing CPI error [%s] from RDE [%s], [%v]", DeleteLoadbalancerError, cgm.ClusterID, err)
 	}
 
-	err = addToEventSet(ctx, cpiRdeManager, DeletedLoadbalancer, cgm.ClusterID, fmt.Sprintf("Successfully deleted loadbalancer associated with [%s], deleted external IP [%s]", cgm.ClusterID, rdeVIP))
+	err = AddToEventSet(ctx, cpiRdeManager, DeletedLoadbalancer, cgm.ClusterID, fmt.Sprintf("Successfully deleted loadbalancer associated with [%s], deleted external IP [%s]", cgm.ClusterID, rdeVIP))
 	if err != nil {
 		klog.Errorf("error adding CPI event to RDE: [%v]", err)
 	}
@@ -208,7 +208,7 @@ func (cgm *CpiGatewayManager) GetLoadBalancer(ctx context.Context, virtualServic
 
 	extIP, err := gm.GetLoadBalancer(ctx, virtualServiceName, oneArm)
 	if err != nil {
-		addToErrorSetErr := addToErrorSet(ctx, cpiRdeManager, GetLoadbalancerError, virtualServiceName, err.Error())
+		addToErrorSetErr := AddToErrorSet(ctx, cpiRdeManager, GetLoadbalancerError, virtualServiceName, err.Error())
 		if addToErrorSetErr != nil {
 			klog.Errorf("unable to add CPI error to RDE [%v]", addToErrorSetErr)
 		}
@@ -230,7 +230,7 @@ func (cgm *CpiGatewayManager) GetLoadBalancerPool(ctx context.Context, lbPoolNam
 	return gm.GetLoadBalancerPool(ctx, lbPoolName)
 }
 
-func addToErrorSet(ctx context.Context, cpiRdeManager *CPIRDEManager, errorName, vcdResourceId, detailedErrorMessage string) error {
+func AddToErrorSet(ctx context.Context, cpiRdeManager *CPIRDEManager, errorName, vcdResourceId, detailedErrorMessage string) error {
 	backendErr := vcdsdk.BackendError{
 		Name:              errorName,
 		OccurredAt:        time.Now(),
@@ -240,12 +240,12 @@ func addToErrorSet(ctx context.Context, cpiRdeManager *CPIRDEManager, errorName,
 	return cpiRdeManager.RDEManager.AddToErrorSet(ctx, vcdsdk.ComponentCPI, backendErr, vcdsdk.DefaultRollingWindowSize)
 }
 
-func addToEventSet(ctx context.Context, cpiRdeManager *CPIRDEManager, eventName, vcdResourceId, detailedErrorMessage string) error {
+func AddToEventSet(ctx context.Context, cpiRdeManager *CPIRDEManager, eventName, vcdResourceId, detailedErrorMessage string) error {
 	backendEvent := vcdsdk.BackendEvent{
 		Name:              eventName,
 		OccurredAt:        time.Now(),
 		VcdResourceId:     vcdResourceId,
-		AdditionalDetails: map[string]interface{}{"Detailed Error": detailedErrorMessage},
+		AdditionalDetails: map[string]interface{}{"Detailed Event": detailedErrorMessage},
 	}
 	return cpiRdeManager.RDEManager.AddToEventSet(ctx, vcdsdk.ComponentCPI, backendEvent, vcdsdk.DefaultRollingWindowSize)
 }

--- a/pkg/vcdsdk/defined_entity.go
+++ b/pkg/vcdsdk/defined_entity.go
@@ -14,8 +14,8 @@ import (
 const (
 	NoRdePrefix = `NO_RDE_`
 
-	MaxRDEUpdateRetries = 10
-
+	MaxRDEUpdateRetries                = 10
+	DefaultRollingWindowSize           = 10
 	ComponentStatusFieldVCDResourceSet = "vcdResourceSet"
 	ComponentStatusFieldErrorSet       = "errorSet"
 	ComponentStatusFieldEventSet       = "eventSet"
@@ -44,6 +44,11 @@ type VCDResource struct {
 	AdditionalDetails map[string]interface{} `json:"additionalDetails,omitempty"`
 }
 
+// TODO: In the future, add subErrorType to AdditionalDetails to handle/match deeper level components removal such as (virtualServiceError, dnatRuleUpdateError, etc)
+// We would need to make AdditionalDetails it's own struct, include a SubErrorType struct/string inside of it
+// During removal, we could match certain subErrorTypes such as delete all LB creation errors that were from subErrorType: virtualServiceFailures
+// AdditionalDetails structure would look something like:
+// additionalDetails : { subErrorType: DNATRuleFailed, additionalInfo: map[string]interface{} }
 type BackendError struct {
 	Name              string                 `json:"name,omitempty"`
 	OccurredAt        time.Time              `json:"occurredAt, omitempty"`


### PR DESCRIPTION
* Ran through systems test for Loadbalancer CRUD operations, observed RDE changes in Postman
* Only contains high level errors such as loadbalancer CRUD errors only rather than inner loadbalancer components such as VS, DNAT, etc
* Updated ccm/CPI image in CAPVCD cluster and able to observe the CPI events/errors during loadbalancer CRUD operations when trying to deploy Wordpress app
* Future to dos: 
    - Go inner to loadbalancer component level errors and categorize them by subtypes nested with additional details
    - Decide if errors from VMs/instances should also be recorded