### PR TITLE
VCDA-3813: Allow no tier0 in common core

### DIFF
--- a/pkg/cpisdk/cpi_gateway_manager.go
+++ b/pkg/cpisdk/cpi_gateway_manager.go
@@ -42,7 +42,7 @@ func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualSer
 	}
 
 	externalIP, err := gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix,
-		ips, portDetailsList, oneArm)
+		ips, portDetailsList, oneArm, false)
 	if err != nil {
 		return "", fmt.Errorf(
 			"unable to create load balancer with vs prefix [%s], lbpool prefix [%s], ips [%v], ports [%v]: [%v]",

--- a/pkg/vcdsdk/ipam.go
+++ b/pkg/vcdsdk/ipam.go
@@ -124,7 +124,8 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 	return freeIP, nil
 }
 
-func (gm *GatewayManager) GetUnusedInternalIPAddress(ctx context.Context, oneArm *OneArm) (string, error) {
+func (gm *GatewayManager) GetUnusedInternalIPAddress(ctx context.Context, oneArm *OneArm,
+	skipAddresses []string) (string, error) {
 	if oneArm == nil {
 		return "", fmt.Errorf("unable to get unused internal IP address as oneArm is nil")
 	}
@@ -135,6 +136,10 @@ func (gm *GatewayManager) GetUnusedInternalIPAddress(ctx context.Context, oneArm
 	client := gm.Client
 
 	usedIPAddresses := make(map[string]bool)
+	for _, skipAddress := range skipAddresses {
+		usedIPAddresses[skipAddress] = true
+	}
+
 	pageNum := int32(1)
 	for {
 		lbVSSummaries, resp, err := client.APIClient.EdgeGatewayLoadBalancerVirtualServicesApi.GetVirtualServiceSummariesForGateway(


### PR DESCRIPTION
This is to help with CAPVCD use case where a user may want to use internal IPs for control plane nodes. The use-case for ingress is not yet well defined and hence CPI does not have the changes yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/93)
<!-- Reviewable:end -->
