### PR TITLE
VCDA-3722: [common-core] allow passing in an IP to CreateLoadBalancer

### DIFF
--- a/pkg/cpisdk/cpi_gateway_manager.go
+++ b/pkg/cpisdk/cpi_gateway_manager.go
@@ -33,8 +33,9 @@ func NewCpiGatewayManager(ctx context.Context, client *vcdsdk.Client, networkNam
 	}, nil
 }
 
-func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualServiceNamePrefix string, lbPoolNamePrefix string,
-	ips []string, portDetailsList []vcdsdk.PortDetails, oneArm *vcdsdk.OneArm, enableVirtualServiceSharedIP bool, portNameToIP map[string]string) (string, error) {
+func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualServiceNamePrefix string,
+	lbPoolNamePrefix string, ips []string, portDetailsList []vcdsdk.PortDetails, oneArm *vcdsdk.OneArm,
+	enableVirtualServiceSharedIP bool, portNameToIP map[string]string) (string, error) {
 
 	gm := cgm.VcdGatewayManager
 	if gm == nil {
@@ -42,7 +43,7 @@ func (cgm *CpiGatewayManager) CreateLoadBalancer(ctx context.Context, virtualSer
 	}
 
 	externalIP, err := gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix,
-		ips, portDetailsList, oneArm, false, enableVirtualServiceSharedIP, portNameToIP)
+		ips, portDetailsList, oneArm, false, enableVirtualServiceSharedIP, portNameToIP, "")
 	if err != nil {
 		return "", fmt.Errorf(
 			"unable to create load balancer with vs prefix [%s], lbpool prefix [%s], ips [%v], ports [%v]: [%v]",


### PR DESCRIPTION
This is to help CAPVCD use customer-specified IP for control-plane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/94)
<!-- Reviewable:end -->
