### PR TITLE
GetLoadBalancer() to return allocated resources map

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -267,7 +267,9 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 	ingressVirtualIP := ""
 	for _, port := range service.Spec.Ports {
 		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, port.Name)
-		virtualIP, err = gm.GetLoadBalancer(ctx, virtualServiceName, lb.OneArm)
+		lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
+		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, port.Name)
+		virtualIP, _, err = gm.GetLoadBalancer(ctx, virtualServiceName, lbPoolName, lb.OneArm)
 		if err != nil {
 			addToErrorSetErr := cpiRdeManager.AddToErrorSetWithNameAndId(ctx, cpisdk.GetLoadbalancerError, "", virtualServiceName, err.Error())
 			if addToErrorSetErr != nil {


### PR DESCRIPTION
Return The allocated resources map when querying for load balancer.
This change helps CAPVCD add the LoadBalancer VCD resources after CAPVCD upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/106)
<!-- Reviewable:end -->
