### PR TITLE
[VCDA-3994] Fix incorrectly persisted userorg when system admin refresh tokens are used

### DIFF
--- a/pkg/vcdsdk/auth.go
+++ b/pkg/vcdsdk/auth.go
@@ -58,6 +58,10 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 				klog.Errorf("failed to authenticate using refresh token")
 				return nil, nil, fmt.Errorf("failed to set authorization header: [%v]", err)
 			}
+		} else {
+			// No error while authenticating with "system" org.
+			// The persisted userorg should be changed to "system"
+			config.UserOrg = "system"
 		}
 		config.IsSysAdmin = vcdClient.Client.IsSysAdmin
 


### PR DESCRIPTION
* Change userorg in vcdAuthConfig to reflect the correct value
* If the attempt to authenticate with system org succeeds, set userorg as system

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/116)
<!-- Reviewable:end -->
