### PR TITLE
VCDA-4186: Add secret-based way to get the Cluster-id so that CRS can use it.

### DIFF
--- a/manifests/cloud-director-ccm-crs.yaml
+++ b/manifests/cloud-director-ccm-crs.yaml
@@ -1,0 +1,193 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:cloud-controller-manager
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: vmware-cloud-director-ccm
+  name: vmware-cloud-director-ccm
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: vmware-cloud-director-ccm
+  template:
+    metadata:
+      labels:
+        app: vmware-cloud-director-ccm
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      dnsPolicy: Default
+      hostNetwork: true
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: vmware-cloud-director-ccm
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/vcloud/bin/cloud-provider-for-cloud-director
+            - --cloud-provider=vmware-cloud-director
+            - --cloud-config=/etc/kubernetes/vcloud/vcloud-ccm-config.yaml
+            - --allow-untagged-cloud=true
+          volumeMounts:
+            - name: vcloud-ccm-config-volume
+              mountPath: /etc/kubernetes/vcloud
+            - name: vcloud-ccm-vcloud-basic-auth-volume
+              mountPath: /etc/kubernetes/vcloud/basic-auth
+          env:
+          - name: CLUSTER_ID
+            valueFrom:
+              secretKeyRef:
+                name: vcloud-clusterid-secret
+                key: clusterid
+      tolerations:
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: "Exists"
+      volumes:
+        - name: vcloud-ccm-config-volume
+          configMap:
+            name: vcloud-ccm-configmap
+        - name: vcloud-ccm-vcloud-basic-auth-volume
+          secret:
+            secretName: vcloud-basic-auth
+---

--- a/manifests/vcloud-configmap.yaml
+++ b/manifests/vcloud-configmap.yaml
@@ -18,7 +18,7 @@ data:
         https: 443
       network: NETWORK
       vipSubnet: VIP_SUBNET_CIDR
-      certAlias: CLUSTER_ID-cert
+      certAlias: CERT_ALIAS
       enableVirtualServiceSharedIP: false # supported for VCD >= 10.4
     clusterid: CLUSTER_ID
     vAppName: VAPP

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"k8s.io/klog"
+	"os"
 	"strings"
 )
 
@@ -81,6 +82,16 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 		return nil, fmt.Errorf("unable to decode yaml file: [%v]", err)
 	}
 	config.VCD.Host = strings.TrimRight(config.VCD.Host, "/")
+
+	if config.ClusterID == "" {
+		config.ClusterID = os.Getenv("CLUSTER_ID")
+		klog.Infof("Using ClusterID [%s] from env since config has an empty string", config.ClusterID)
+	}
+	if config.LB.CertificateAlias == "" {
+		config.LB.CertificateAlias = fmt.Sprintf("%s-cert", config.ClusterID)
+		klog.Infof("Using certAlias [%s] from env since config has an empty string", config.LB.CertificateAlias)
+	}
+
 	return config, nil
 }
 


### PR DESCRIPTION
A new manifest file named `cloud-director-ccm-crs.yaml` has been created. This will be used by those installations that use CRS. This needs to be converted into a secret and used. (The documentation will later be added in CAPVCD repo).

There is a reference in this file to ClusterID coming in as a secret. (Env in line 165). So until that env is set, the CPI pod will be in a ConfigError loop. Once the secret is set, the pod will start up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/119)
<!-- Reviewable:end -->
