### PR TITLE
[VCDA-4204]Add security context to deployment manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ COPY --from=builder /build/vcloud/cloud-provider-for-cloud-director .
 
 RUN chmod +x /opt/vcloud/bin/cloud-provider-for-cloud-director
 
-# USER nobody
+USER nobody
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/manifests/cloud-director-ccm-crs.yaml
+++ b/manifests/cloud-director-ccm-crs.yaml
@@ -148,6 +148,10 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       serviceAccountName: cloud-controller-manager
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
           image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -148,6 +148,10 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       serviceAccountName: cloud-controller-manager
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
           image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>
- Docker container should with USER nobody
- Add securityContext to deployment spec

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/121)
<!-- Reviewable:end -->
