### PR TITLE
[VCDA-4178] Add wire logging to CPI containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ COPY --from=builder /go/src/github.com/vmware/cloud-provider-for-cloud-director/
 COPY --from=builder /build/vcloud/cloud-provider-for-cloud-director .
 
 RUN chmod +x /opt/vcloud/bin/cloud-provider-for-cloud-director
+RUN mkdir /opt/vcloud/logs
+RUN touch /opt/vcloud/logs/cpi-wire-log.txt
+RUN chmod 666 /opt/vcloud/logs/cpi-wire-log.txt
 
 # USER nobody
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/manifests/cloud-director-ccm-crs.yaml
+++ b/manifests/cloud-director-ccm-crs.yaml
@@ -168,6 +168,10 @@ spec:
               secretKeyRef:
                 name: vcloud-clusterid-secret
                 key: clusterid
+          - name: GOVCD_LOG
+            value: "true"
+          - name: GOVCD_LOG_FILE
+            value: "/opt/vcloud/logs/cpi-wire-log.txt"
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -162,6 +162,11 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+          env:
+          - name: GOVCD_LOG
+            value: "true"
+          - name: GOVCD_LOG_FILE
+            value: "/opt/vcloud/logs/cpi-wire-log.txt"
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"


### PR DESCRIPTION
* Set GOVCD environment variables in deployment spec to enable wire logging
* Set permissions for the log file in Dockerfile to help CPI log requests and responses to access the log file for writing


Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/122)
<!-- Reviewable:end -->
