### PR TITLE
VCDA-4331: append git sha to dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,18 @@ build-within-docker:
 ccm: $(GO_CODE)
 	docker build -f Dockerfile . -t cloud-provider-for-cloud-director:$(version)
 	docker tag cloud-provider-for-cloud-director:$(version) $(REGISTRY)/cloud-provider-for-cloud-director:$(version)
-	# docker tag cloud-provider-for-cloud-director:$(version).latest $(REGISTRY)/cloud-provider-for-cloud-director:$(version).$$(docker images cloud-provider-for-cloud-director:$(version) -q)
+	docker tag cloud-provider-for-cloud-director:$(version) $(REGISTRY)/cloud-provider-for-cloud-director:$(version).$(GITCOMMIT)
 	docker push $(REGISTRY)/cloud-provider-for-cloud-director:$(version)
 	touch out/$@
 
-all: ccm
+prod: ccm
+	sed -e "s/\.__GIT_COMMIT__//g" manifests/cloud-director-ccm.yaml.template > manifests/cloud-director-ccm.yaml
+	sed -e "s/\.__GIT_COMMIT__//g" manifests/cloud-director-ccm-crs.yaml.template > manifests/cloud-director-ccm-crs.yaml
+
+dev: ccm
+	docker push $(REGISTRY)/cloud-provider-for-cloud-director:$(version).$(GITCOMMIT)
+	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" manifests/cloud-director-ccm.yaml.template > manifests/cloud-director-ccm.yaml
+	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" manifests/cloud-director-ccm-crs.yaml.template > manifests/cloud-director-ccm-crs.yaml
 
 vendor:
 	go mod edit -go=1.17

--- a/manifests/cloud-director-ccm-crs.yaml.template
+++ b/manifests/cloud-director-ccm-crs.yaml.template
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.81b03e6
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.__GIT_COMMIT__
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.81b03e6
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml.template
+++ b/manifests/cloud-director-ccm.yaml.template
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.81b03e6
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.__GIT_COMMIT__
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director
@@ -166,12 +166,6 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
-          env:
-          - name: CLUSTER_ID
-            valueFrom:
-              secretKeyRef:
-                name: vcloud-clusterid-secret
-                key: clusterid
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"


### PR DESCRIPTION
This will embed the git sha in the tag of the image. To use the image of a particular git sha, use the git sha that references the image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/125)
<!-- Reviewable:end -->
