### PR TITLE
VCDA-4532: AutoGenerate Password for VMs

### DIFF
--- a/pkg/vcdsdk/common_system_test.go
+++ b/pkg/vcdsdk/common_system_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var (
@@ -109,7 +110,7 @@ func getTestVCDClient(vcdConfig *VcdConfig, inputMap map[string]interface{}) (*C
 	}
 
 	return NewVCDClientFromSecrets(
-		vcdConfigCopy.Host,
+		strings.TrimRight(vcdConfigCopy.Host, "/"),
 		vcdConfigCopy.TenantOrg,
 		vcdConfigCopy.TenantVdc,
 		vcdConfigCopy.UserOrg,

--- a/pkg/vcdsdk/vapp.go
+++ b/pkg/vcdsdk/vapp.go
@@ -28,6 +28,11 @@ const (
 	VCDVMIDPrefix = "urn:vcloud:vm:"
 )
 
+var (
+	trueVar     = true
+	falseVar    = false
+)
+
 type VdcManager struct {
 	OrgName string
 	VdcName string
@@ -638,6 +643,12 @@ func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, v
 				},
 				VAppScopedLocalID: vmName,
 				InstantiationParams: &types.InstantiationParams{
+					GuestCustomizationSection: &types.GuestCustomizationSection{
+						Enabled:               &trueVar,
+						AdminPasswordEnabled:  &trueVar,
+						AdminPasswordAuto:     &trueVar,
+						ResetPasswordRequired: &falseVar,
+					},
 					NetworkConnectionSection: &types.NetworkConnectionSection{
 						NetworkConnection: []*types.NetworkConnection{
 							{

--- a/pkg/vcdsdk/vapp_test.go
+++ b/pkg/vcdsdk/vapp_test.go
@@ -24,7 +24,7 @@ func TestVApp(t *testing.T) {
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
 	// create vApp
-	vAppName := "manual-vapp"
+	vAppName := "test-vapp"
 	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCName)
 	assert.NoError(t, err, "error creating VDCManager")
 
@@ -32,6 +32,13 @@ func TestVApp(t *testing.T) {
 	vappObj, err := vdcManager.GetOrCreateVApp(vAppName, vcdConfig.OvdcNetwork)
 	assert.NoError(t, err, "error creating VApp")
 	assert.NotNil(t, vappObj, "vApp created should not be nil")
+
+	// create VM
+	vmNamePrefix := "test-vm"
+	err = vdcManager.AddNewVM(vmNamePrefix, vAppName, 1, "cse",
+		"Ubuntu 20.04 and Kubernetes v1.21.11+vmware.1", "", "4core4gb",
+		"", "", true)
+	assert.NoError(t, err, "should create vm correctly")
 
 	vms, err := vdcManager.FindAllVMsInVapp(vAppName)
 	assert.NoError(t, err, "unable to find VMs in vApp")


### PR DESCRIPTION
Here we enable the autogenerate password so that templates which don't have this parameter set will still be able to get a password for remote console.

This is a common core change to be used in CAPVCD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/132)
<!-- Reviewable:end -->
