### PR TITLE
[VCDA-4563] Reduce updates to RDE by only updating the VCD Resource set when there is a change

### DIFF
--- a/pkg/cpisdk/rde.go
+++ b/pkg/cpisdk/rde.go
@@ -369,11 +369,16 @@ func (cpiRDEManager *CPIRDEManager) AddVIPToVCDResourceSet(ctx context.Context, 
 				"virtualIP": externalIP,
 			},
 		}
-		updatedStatusMap, err := vcdsdk.AddVCDResourceToStatusMap(vcdsdk.ComponentCPI, cpiRDEManager.RDEManager.StatusComponentName,
+		updatedStatusMap, rdeUpdateRequired, err := vcdsdk.AddVCDResourceToStatusMap(vcdsdk.ComponentCPI, cpiRDEManager.RDEManager.StatusComponentName,
 			cpiRDEManager.RDEManager.StatusComponentVersion, statusMap, vcdResource)
 		if err != nil {
 			return fmt.Errorf("error occurred when updating VCDResource set of %s status in RDE [%s]: [%v]",
 				cpiRDEManager.RDEManager.ClusterID, vcdsdk.ComponentCPI, err)
+		}
+		if !rdeUpdateRequired {
+			klog.V(3).Info("VCD resource set for the RDE [%s(%s)] already has the resource [%v] in the status of the component [%s]",
+				rde.Name, rde.Id, vcdResource, vcdsdk.ComponentCPI)
+			return nil
 		}
 
 		// remove the VIP from old "status.virtualIPs" key if present

--- a/pkg/vcdsdk/defined_entity.go
+++ b/pkg/vcdsdk/defined_entity.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/klog"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -137,7 +138,7 @@ func convertMapToComponentStatus(componentStatusMap map[string]interface{}) (*Co
 
 // AddVCDResourceToStatusMap updates the input status map with VCDResource created from the input parameters. This function doesn't make any
 // 	calls to VCD.
-func AddVCDResourceToStatusMap(component string, componentName string, componentVersion string, statusMap map[string]interface{}, vcdResource VCDResource) (map[string]interface{}, error) {
+func AddVCDResourceToStatusMap(component string, componentName string, componentVersion string, statusMap map[string]interface{}, vcdResource VCDResource) (map[string]interface{}, bool,  error) {
 	// get the component info from the status
 	componentIf, ok := statusMap[component]
 	if !ok {
@@ -150,17 +151,17 @@ func AddVCDResourceToStatusMap(component string, componentName string, component
 			},
 		}
 		klog.V(3).Infof("created component map [%#v] since the component was not found in the status map", statusMap[component])
-		return statusMap, nil
+		return statusMap, true,  nil
 	}
 
 	componentMap, ok := componentIf.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("failed to convert the status belonging to component [%s] to map[string]interface{}", component)
+		return nil, false, fmt.Errorf("failed to convert the status belonging to component [%s] to map[string]interface{}", component)
 	}
 
 	componentStatus, err := convertMapToComponentStatus(componentMap)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert component status map to component status object")
+		return nil, false, fmt.Errorf("failed to convert component status map to component status object")
 	}
 
 	if componentStatus.VCDResourceSet == nil || len(componentStatus.VCDResourceSet) == 0 {
@@ -170,24 +171,28 @@ func AddVCDResourceToStatusMap(component string, componentName string, component
 		}
 		componentMap["name"] = componentName
 		componentMap["version"] = componentVersion
-		return statusMap, nil
+		return statusMap, true, nil
 	}
 
+	updateRequired := true
 	resourceFound := false
 	// check if vcdResource is already present
 	for idx, resource := range componentStatus.VCDResourceSet {
 		if resource.ID == vcdResource.ID && resource.Type == vcdResource.Type {
 			resourceFound = true
+			if reflect.DeepEqual(resource.AdditionalDetails, vcdResource.AdditionalDetails) {
+				updateRequired = false
+			}
 			componentStatus.VCDResourceSet[idx].AdditionalDetails = vcdResource.AdditionalDetails
+			break
 		}
 	}
-
 	if !resourceFound {
 		componentStatus.VCDResourceSet = append(componentStatus.VCDResourceSet, vcdResource)
 	}
 
 	componentMap[ComponentStatusFieldVCDResourceSet] = componentStatus.VCDResourceSet
-	return statusMap, nil
+	return statusMap, updateRequired, nil
 }
 
 /*
@@ -611,10 +616,15 @@ func (rdeManager *RDEManager) AddToVCDResourceSet(ctx context.Context, component
 			Name:              resourceName,
 			AdditionalDetails: additionalDetails,
 		}
-		updatedStatusMap, err := AddVCDResourceToStatusMap(component, rdeManager.StatusComponentName,
+		updatedStatusMap, rdeUpdateRequried, err := AddVCDResourceToStatusMap(component, rdeManager.StatusComponentName,
 			rdeManager.StatusComponentVersion, statusMap, vcdResource)
 		if err != nil {
 			return fmt.Errorf("error occurred when updating VCDResource set of %s status in RDE [%s]: [%v]", rdeManager.ClusterID, component, err)
+		}
+		if !rdeUpdateRequried {
+			klog.V(3).Info("VCD resource set for the RDE [%s(%s)] already has the resource [%v] in the status of the component [%s]",
+				rde.Name, rde.Id, vcdResource, component)
+			return nil
 		}
 		rde.Entity["status"] = updatedStatusMap
 		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)

--- a/pkg/vcdsdk/defined_entity.go
+++ b/pkg/vcdsdk/defined_entity.go
@@ -616,12 +616,12 @@ func (rdeManager *RDEManager) AddToVCDResourceSet(ctx context.Context, component
 			Name:              resourceName,
 			AdditionalDetails: additionalDetails,
 		}
-		updatedStatusMap, rdeUpdateRequried, err := AddVCDResourceToStatusMap(component, rdeManager.StatusComponentName,
+		updatedStatusMap, rdeUpdateRequired, err := AddVCDResourceToStatusMap(component, rdeManager.StatusComponentName,
 			rdeManager.StatusComponentVersion, statusMap, vcdResource)
 		if err != nil {
 			return fmt.Errorf("error occurred when updating VCDResource set of %s status in RDE [%s]: [%v]", rdeManager.ClusterID, component, err)
 		}
-		if !rdeUpdateRequried {
+		if !rdeUpdateRequired {
 			klog.V(3).Infof("VCD resource set for the RDE [%s(%s)] already has the resource [%v] in the status of the component [%s]",
 				rde.Name, rde.Id, vcdResource, component)
 			return nil

--- a/pkg/vcdsdk/defined_entity.go
+++ b/pkg/vcdsdk/defined_entity.go
@@ -622,7 +622,7 @@ func (rdeManager *RDEManager) AddToVCDResourceSet(ctx context.Context, component
 			return fmt.Errorf("error occurred when updating VCDResource set of %s status in RDE [%s]: [%v]", rdeManager.ClusterID, component, err)
 		}
 		if !rdeUpdateRequried {
-			klog.V(3).Info("VCD resource set for the RDE [%s(%s)] already has the resource [%v] in the status of the component [%s]",
+			klog.V(3).Infof("VCD resource set for the RDE [%s(%s)] already has the resource [%v] in the status of the component [%s]",
 				rde.Name, rde.Id, vcdResource, component)
 			return nil
 		}

--- a/pkg/vcdsdk/defined_entity_test.go
+++ b/pkg/vcdsdk/defined_entity_test.go
@@ -228,6 +228,7 @@ func TestAddToVCDResourceSet(t *testing.T) {
 		VCDResource    VCDResource
 		ExpectedStatus map[string]interface{}
 		Message        string
+		ExpectedUpdateRequired bool
 	}
 	testCaseList := []TestCase{
 		{
@@ -286,6 +287,7 @@ func TestAddToVCDResourceSet(t *testing.T) {
 					"key1": "value1",
 				},
 			},
+			ExpectedUpdateRequired: true,
 		},
 		{
 			Message: "do not add duplicate resource when it is already present in VCD resource set",
@@ -341,6 +343,7 @@ func TestAddToVCDResourceSet(t *testing.T) {
 					"key1": "value1",
 				},
 			},
+			ExpectedUpdateRequired:  false,
 		},
 		{
 			Message: "recreate CPI status if absent",
@@ -382,11 +385,13 @@ func TestAddToVCDResourceSet(t *testing.T) {
 					"key1": "value1",
 				},
 			},
+			ExpectedUpdateRequired: true,
 		},
 	}
 	for _, tc := range testCaseList {
-		updatedStatusMap, err := AddVCDResourceToStatusMap(ComponentCPI, "ccm", "1.1.1", tc.StatusMap, tc.VCDResource)
+		updatedStatusMap, updateRequired, err := AddVCDResourceToStatusMap(ComponentCPI, "ccm", "1.1.1", tc.StatusMap, tc.VCDResource)
 		assert.NoError(t, err, "Expected no error ", tc.Message)
+		assert.Equal(t, tc.ExpectedUpdateRequired, updateRequired, "Update required flag returned was not as expected")
 
 		actualJson, err := convertToJson(updatedStatusMap)
 		assert.NoError(t, err, tc.Message, "expected no error converting updatedStatusMap to json")


### PR DESCRIPTION
* Avoid RDE updates when vcd resource is already present in the vcd resource set and there is no change in the vcd resource being added
* Tested by executing the tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/133)
<!-- Reviewable:end -->
