### PR TITLE
[VCDA-44481] Clean up logs spammed with “wrong etag” statements in CPI common code

### DIFF
--- a/pkg/vcdsdk/defined_entity.go
+++ b/pkg/vcdsdk/defined_entity.go
@@ -138,7 +138,7 @@ func convertMapToComponentStatus(componentStatusMap map[string]interface{}) (*Co
 
 // AddVCDResourceToStatusMap updates the input status map with VCDResource created from the input parameters. This function doesn't make any
 // 	calls to VCD.
-func AddVCDResourceToStatusMap(component string, componentName string, componentVersion string, statusMap map[string]interface{}, vcdResource VCDResource) (map[string]interface{}, bool,  error) {
+func AddVCDResourceToStatusMap(component string, componentName string, componentVersion string, statusMap map[string]interface{}, vcdResource VCDResource) (map[string]interface{}, bool, error) {
 	// get the component info from the status
 	componentIf, ok := statusMap[component]
 	if !ok {
@@ -151,7 +151,7 @@ func AddVCDResourceToStatusMap(component string, componentName string, component
 			},
 		}
 		klog.V(3).Infof("created component map [%#v] since the component was not found in the status map", statusMap[component])
-		return statusMap, true,  nil
+		return statusMap, true, nil
 	}
 
 	componentMap, ok := componentIf.(map[string]interface{})
@@ -265,7 +265,7 @@ func (rdeManager *RDEManager) AddToErrorSet(ctx context.Context, componentSectio
 		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
 		if resp != nil {
 			if resp.StatusCode == http.StatusPreconditionFailed {
-				klog.Errorf("wrong etag while adding newError [%v] in RDE [%s]. Retry attempts remaining: [%d]", newError, rdeManager.ClusterID, i-1)
+				klog.V(4).Infof("wrong etag while adding newError [%v] in RDE [%s]. Retry attempts remaining: [%d]", newError, rdeManager.ClusterID, i-1)
 				continue
 			} else if resp.StatusCode != http.StatusOK {
 				var responseMessageBytes []byte
@@ -522,7 +522,7 @@ func (rdeManager *RDEManager) AddToEventSet(ctx context.Context, componentSectio
 		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
 		if resp != nil {
 			if resp.StatusCode == http.StatusPreconditionFailed {
-				klog.Errorf("wrong etag while adding newEvent [%#v] in RDE [%s]. Retry attempts remaining: [%d]", newEvent, rdeManager.ClusterID, i-1)
+				klog.V(4).Infof("wrong etag [%s] while adding newEvent [%s] in RDE [%s]. Retry attempts remaining: [%d]", etag, newEvent.Name, rdeManager.ClusterID, i-1)
 				continue
 			} else if resp.StatusCode != http.StatusOK {
 				var responseMessageBytes []byte
@@ -630,7 +630,7 @@ func (rdeManager *RDEManager) AddToVCDResourceSet(ctx context.Context, component
 		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
 		if resp != nil {
 			if resp.StatusCode == http.StatusPreconditionFailed {
-				klog.Errorf("wrong etag while adding [%v] to VCDResourceSet in RDE [%s]. Retry attempts remaining: [%d]", vcdResource, rdeManager.ClusterID, i-1)
+				klog.V(4).Infof("wrong etag [%s] while adding [%s/%s] to VCDResourceSet in RDE [%s]. Retry attempts remaining: [%d]", etag, vcdResource.Type, vcdResource.Name, rdeManager.ClusterID, i-1)
 				continue
 			} else if resp.StatusCode != http.StatusOK {
 				var responseMessageBytes []byte
@@ -752,7 +752,7 @@ func (rdeManager *RDEManager) RemoveFromVCDResourceSet(ctx context.Context, comp
 		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
 		if resp != nil {
 			if resp.StatusCode == http.StatusPreconditionFailed {
-				klog.Errorf("wrong etag while removing [%s] from VCDResourceSet in RDE [%s]. Retry attempts remaining: [%d]", resourceName, rdeManager.ClusterID, i-1)
+				klog.V(4).Infof("wrong etag [%s] while removing [%s/%s] from VCDResourceSet in RDE [%s]. Retry attempts remaining: [%d]", etag, resourceType, resourceName, rdeManager.ClusterID, i-1)
 				continue
 			} else if resp.StatusCode != http.StatusOK {
 				var responseMessageBytes []byte

--- a/pkg/vcdsdk/defined_entity.go
+++ b/pkg/vcdsdk/defined_entity.go
@@ -265,7 +265,7 @@ func (rdeManager *RDEManager) AddToErrorSet(ctx context.Context, componentSectio
 		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
 		if resp != nil {
 			if resp.StatusCode == http.StatusPreconditionFailed {
-				klog.V(4).Infof("wrong etag while adding newError [%v] in RDE [%s]. Retry attempts remaining: [%d]", newError, rdeManager.ClusterID, i-1)
+				klog.V(4).Infof("wrong etag [%s] while adding newError [%s] in RDE [%s]. Retry attempts remaining: [%d]", etag, newError.Name, rdeManager.ClusterID, i-1)
 				continue
 			} else if resp.StatusCode != http.StatusOK {
 				var responseMessageBytes []byte


### PR DESCRIPTION
* Clean up spammed etag logging statements in CAPVCD
* Increase the verbosity of logging level

Signed-off-by: ymo24 <ymo@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/134)
<!-- Reviewable:end -->
