### PR TITLE
[VCDA-4586] Add tenant context header to the get ovdc networks function

### DIFF
--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -39,10 +39,6 @@ type GatewayManager struct {
 
 // CacheGatewayDetails get gateway reference and cache some details in client object
 func (gatewayManager *GatewayManager) cacheGatewayDetails(ctx context.Context) error {
-	if gatewayManager.Client.VDC == nil || gatewayManager.Client.VDC.Vdc == nil {
-		return fmt.Errorf("VDC cannot be nil")
-	}
-
 	if gatewayManager.NetworkName == "" {
 		return fmt.Errorf("network name should not be empty")
 	}
@@ -124,7 +120,7 @@ func (gatewayManager *GatewayManager) getOVDCNetwork(ctx context.Context, networ
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
 			if networkFound {
-				return nil, fmt.Errorf("found more than one network with the name [%s] found in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
+				return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
 			}
 			if ovdcNetwork.Name == gatewayManager.NetworkName {
 				ovdcNetworkID = ovdcNetwork.Id

--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -39,6 +39,9 @@ type GatewayManager struct {
 
 // CacheGatewayDetails get gateway reference and cache some details in client object
 func (gatewayManager *GatewayManager) cacheGatewayDetails(ctx context.Context) error {
+	if gatewayManager.Client.VDC == nil || gatewayManager.Client.VDC.Vdc == nil {
+		return fmt.Errorf("VDC cannot be nil")
+	}
 
 	if gatewayManager.NetworkName == "" {
 		return fmt.Errorf("network name should not be empty")
@@ -100,8 +103,16 @@ func (gatewayManager *GatewayManager) getOVDCNetwork(ctx context.Context, networ
 	ovdcNetworksAPI := client.APIClient.OrgVdcNetworksApi
 	pageNum := int32(1)
 	ovdcNetworkID := ""
+	org, err := client.VCDClient.GetOrgByName(client.ClusterOrgName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting org by name for org [%s]: [%v]", client.ClusterOrgName, err)
+	}
+	if org == nil || org.Org == nil {
+		return nil, fmt.Errorf("obtained nil org when getting org by name [%s]", client.ClusterOrgName)
+	}
+	networkFound := false
 	for {
-		ovdcNetworks, resp, err := ovdcNetworksAPI.GetAllVdcNetworks(ctx, pageNum, 32, nil)
+		ovdcNetworks, resp, err := ovdcNetworksAPI.GetAllVdcNetworks(ctx, org.Org.ID, pageNum, 32, nil)
 		if err != nil {
 			// TODO: log resp in debug mode only
 			return nil, fmt.Errorf("unable to get all ovdc networks: [%+v]: [%v]", resp, err)
@@ -112,14 +123,13 @@ func (gatewayManager *GatewayManager) getOVDCNetwork(ctx context.Context, networ
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
+			if networkFound {
+				return nil, fmt.Errorf("found more than one network with the name [%s] found in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
+			}
 			if ovdcNetwork.Name == gatewayManager.NetworkName {
 				ovdcNetworkID = ovdcNetwork.Id
-				break
+				networkFound = true
 			}
-		}
-
-		if ovdcNetworkID != "" {
-			break
 		}
 		pageNum++
 	}

--- a/pkg/vcdswaggerclient/api_org_vdc_networks.go
+++ b/pkg/vcdswaggerclient/api_org_vdc_networks.go
@@ -139,7 +139,7 @@ type OrgVdcNetworksApiGetAllVdcNetworksOpts struct {
 	SortDesc optional.String
 }
 
-func (a *OrgVdcNetworksApiService) GetAllVdcNetworks(ctx context.Context, page int32, pageSize int32, localVarOptionals *OrgVdcNetworksApiGetAllVdcNetworksOpts) (VdcNetworks, *http.Response, error) {
+func (a *OrgVdcNetworksApiService) GetAllVdcNetworks(ctx context.Context, orgID string, page int32, pageSize int32, localVarOptionals *OrgVdcNetworksApiGetAllVdcNetworksOpts) (VdcNetworks, *http.Response, error) {
 	var (
 		localVarHttpMethod  = strings.ToUpper("Get")
 		localVarPostBody    interface{}
@@ -204,6 +204,9 @@ func (a *OrgVdcNetworksApiService) GetAllVdcNetworks(ctx context.Context, page i
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams["X-VMWARE-VCLOUD-TENANT-CONTEXT"] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {


### PR DESCRIPTION
* Prevents system org user from caching an incorrect gateway in a scenario where there are more than one network with the same name, belonging to different org and connected to different tenant edge gateways

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/135)
<!-- Reviewable:end -->
