### PR TITLE
[VCDA-4627] Cloud api calls should send in a tenant context header to scope requests to the cluster's organization

### DIFF
--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -50,7 +50,7 @@ func (client *Client) getOVDCNetwork(ctx context.Context, networkName string) (*
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if ovdcNetworkID == ovdcNetwork.Id {
+			if networkName == ovdcNetwork.Name {
 				if networkFound {
 					return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", networkName, client.ClusterOrgName)
 				}

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -50,11 +50,13 @@ func (client *Client) getOVDCNetwork(ctx context.Context, networkName string) (*
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if networkFound {
-				return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", networkName, client.ClusterOrgName)
+			if ovdcNetworkID == ovdcNetwork.Id {
+				if networkFound {
+					return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", networkName, client.ClusterOrgName)
+				}
+				ovdcNetworkID = ovdcNetwork.Id
+				networkFound = true
 			}
-			ovdcNetworkID = ovdcNetwork.Id
-			networkFound = true
 		}
 		pageNum++
 	}

--- a/pkg/vcdswaggerclient/api_certificate_library_modified.go
+++ b/pkg/vcdswaggerclient/api_certificate_library_modified.go
@@ -25,10 +25,6 @@ var (
 	_ context.Context
 )
 
-const (
-	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
-)
-
 type CertificateLibraryApiService service
 
 /*

--- a/pkg/vcdswaggerclient/api_certificate_library_modified.go
+++ b/pkg/vcdswaggerclient/api_certificate_library_modified.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -24,6 +23,10 @@ import (
 // Linger please
 var (
 	_ context.Context
+)
+
+const (
+	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
 )
 
 type CertificateLibraryApiService service
@@ -627,7 +630,7 @@ func (a *CertificateLibraryApiService) QueryCertificateLibrary(ctx context.Conte
 
 	// if there is an orgID set, use the appropriate header
 	if orgID != "" {
-		localVarHeaderParams["X-VMWARE-VCLOUD-TENANT-CONTEXT"] = orgID
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 
 	if ctx != nil {

--- a/pkg/vcdswaggerclient/api_defined_entity.go
+++ b/pkg/vcdswaggerclient/api_defined_entity.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -44,7 +43,7 @@ type DefinedEntityApiCreateDefinedEntityOpts struct {
 	InvokeHooks optional.Interface
 }
 
-func (a *DefinedEntityApiService) CreateDefinedEntity(ctx context.Context, entity DefinedEntity, id string, localVarOptionals *DefinedEntityApiCreateDefinedEntityOpts) (*http.Response, error) {
+func (a *DefinedEntityApiService) CreateDefinedEntity(ctx context.Context, entity DefinedEntity, id string, orgID string, localVarOptionals *DefinedEntityApiCreateDefinedEntityOpts) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -95,6 +94,9 @@ func (a *DefinedEntityApiService) CreateDefinedEntity(ctx context.Context, entit
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -151,13 +153,12 @@ type DefinedEntityApiDeleteDefinedEntityOpts struct {
 	InvokeHooks optional.Interface
 }
 
-func (a *DefinedEntityApiService) DeleteDefinedEntity(ctx context.Context, id string, localVarOptionals *DefinedEntityApiDeleteDefinedEntityOpts) (*http.Response, error) {
+func (a *DefinedEntityApiService) DeleteDefinedEntity(ctx context.Context, id string, orgID string, localVarOptionals *DefinedEntityApiDeleteDefinedEntityOpts) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
-
 	)
 
 	// create path and map variables
@@ -200,6 +201,9 @@ func (a *DefinedEntityApiService) DeleteDefinedEntity(ctx context.Context, id st
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -253,7 +257,7 @@ type DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts struct {
 	SortDesc optional.String
 }
 
-func (a *DefinedEntityApiService) GetDefinedEntitiesByEntityType(ctx context.Context, vendor string, nss string, version string, page int32, pageSize int32, localVarOptionals *DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts) (DefinedEntities, *http.Response, error) {
+func (a *DefinedEntityApiService) GetDefinedEntitiesByEntityType(ctx context.Context, vendor string, nss string, version string, orgID string, page int32, pageSize int32, localVarOptionals *DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts) (DefinedEntities, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -331,6 +335,9 @@ func (a *DefinedEntityApiService) GetDefinedEntitiesByEntityType(ctx context.Con
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -399,7 +406,7 @@ type DefinedEntityApiGetDefinedEntitiesByInterfaceOpts struct {
 	SortDesc optional.String
 }
 
-func (a *DefinedEntityApiService) GetDefinedEntitiesByInterface(ctx context.Context, vendor string, nss string, version string, page int32, pageSize int32, localVarOptionals *DefinedEntityApiGetDefinedEntitiesByInterfaceOpts) (DefinedEntities, *http.Response, error) {
+func (a *DefinedEntityApiService) GetDefinedEntitiesByInterface(ctx context.Context, vendor string, nss string, version string, orgID string, page int32, pageSize int32, localVarOptionals *DefinedEntityApiGetDefinedEntitiesByInterfaceOpts) (DefinedEntities, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -477,6 +484,9 @@ func (a *DefinedEntityApiService) GetDefinedEntitiesByInterface(ctx context.Cont
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -530,7 +540,7 @@ Gets the defined entity with the unique identifier (URN)
 
 @return DefinedEntity
 */
-func (a *DefinedEntityApiService) GetDefinedEntity(ctx context.Context, id string) (DefinedEntity, *http.Response, string, error) {
+func (a *DefinedEntityApiService) GetDefinedEntity(ctx context.Context, id string, orgID string) (DefinedEntity, *http.Response, string, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -577,6 +587,9 @@ func (a *DefinedEntityApiService) GetDefinedEntity(ctx context.Context, id strin
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, "", err
@@ -608,8 +621,6 @@ func (a *DefinedEntityApiService) GetDefinedEntity(ctx context.Context, id strin
 	}
 }
 
-
-
 /*
 DefinedEntityApiService Validates the defined entity against the entity type schema.
 Validates the defined entity against the entity type schema. If the validation is successful, the entity will transition to a \&quot;RESOLVED\&quot; state. Otherwise, it will transition to an \&quot;ERROR\&quot; state.
@@ -618,7 +629,7 @@ Validates the defined entity against the entity type schema. If the validation i
 
 @return EntityState
 */
-func (a *DefinedEntityApiService) ResolveDefinedEntity(ctx context.Context, id string) (EntityState, *http.Response, error) {
+func (a *DefinedEntityApiService) ResolveDefinedEntity(ctx context.Context, id string, orgID string) (EntityState, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -664,6 +675,9 @@ func (a *DefinedEntityApiService) ResolveDefinedEntity(ctx context.Context, id s
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -726,7 +740,7 @@ type DefinedEntityApiUpdateDefinedEntityOpts struct {
 	InvokeHooks optional.Interface
 }
 
-func (a *DefinedEntityApiService) UpdateDefinedEntity(ctx context.Context, entity DefinedEntity, etag string, id string, localVarOptionals *DefinedEntityApiUpdateDefinedEntityOpts) (DefinedEntity, *http.Response, error) {
+func (a *DefinedEntityApiService) UpdateDefinedEntity(ctx context.Context, entity DefinedEntity, etag string, id string, orgID string, localVarOptionals *DefinedEntityApiUpdateDefinedEntityOpts) (DefinedEntity, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -781,6 +795,9 @@ func (a *DefinedEntityApiService) UpdateDefinedEntity(ctx context.Context, entit
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/api_edge_gateway.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -140,7 +139,7 @@ EdgeGatewayApiService Retrieves a specific Edge Gateway
 
 @return EdgeGateway
 */
-func (a *EdgeGatewayApiService) GetEdgeGateway(ctx context.Context, gatewayId string) (EdgeGateway, *http.Response, error) {
+func (a *EdgeGatewayApiService) GetEdgeGateway(ctx context.Context, gatewayId string, orgID string) (EdgeGateway, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -186,6 +185,9 @@ func (a *EdgeGatewayApiService) GetEdgeGateway(ctx context.Context, gatewayId st
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -264,7 +266,7 @@ type EdgeGatewayApiGetUsedIpAddressesOpts struct {
 	SortDesc optional.String
 }
 
-func (a *EdgeGatewayApiService) GetUsedIpAddresses(ctx context.Context, page int32, pageSize int32, gatewayId string, localVarOptionals *EdgeGatewayApiGetUsedIpAddressesOpts) (GatewayUsedIpAddresses, *http.Response, error) {
+func (a *EdgeGatewayApiService) GetUsedIpAddresses(ctx context.Context, page int32, pageSize int32, gatewayId string, orgID string, localVarOptionals *EdgeGatewayApiGetUsedIpAddressesOpts) (GatewayUsedIpAddresses, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -330,6 +332,9 @@ func (a *EdgeGatewayApiService) GetUsedIpAddresses(ctx context.Context, page int
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_pool.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_pool.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -34,7 +33,7 @@ EdgeGatewayLoadBalancerPoolApiService Deletes a specific Load Balancer Pool.
 
 
 */
-func (a *EdgeGatewayLoadBalancerPoolApiService) DeleteLoadBalancerPool(ctx context.Context, poolId string) (*http.Response, error) {
+func (a *EdgeGatewayLoadBalancerPoolApiService) DeleteLoadBalancerPool(ctx context.Context, poolId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -80,6 +79,9 @@ func (a *EdgeGatewayLoadBalancerPoolApiService) DeleteLoadBalancerPool(ctx conte
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -128,7 +130,7 @@ EdgeGatewayLoadBalancerPoolApiService Retrieves a specific Load Balancer Pool.
 
 @return EdgeLoadBalancerPool
 */
-func (a *EdgeGatewayLoadBalancerPoolApiService) GetLoadBalancerPool(ctx context.Context, poolId string) (EdgeLoadBalancerPool, *http.Response, error) {
+func (a *EdgeGatewayLoadBalancerPoolApiService) GetLoadBalancerPool(ctx context.Context, poolId string, orgID string) (EdgeLoadBalancerPool, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -174,6 +176,9 @@ func (a *EdgeGatewayLoadBalancerPoolApiService) GetLoadBalancerPool(ctx context.
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -228,7 +233,7 @@ EdgeGatewayLoadBalancerPoolApiService Updates a specific Load Balancer Pool.
 
 
 */
-func (a *EdgeGatewayLoadBalancerPoolApiService) UpdateLoadBalancerPool(ctx context.Context, loadBalancerPool EdgeLoadBalancerPool, poolId string) (*http.Response, error) {
+func (a *EdgeGatewayLoadBalancerPoolApiService) UpdateLoadBalancerPool(ctx context.Context, loadBalancerPool EdgeLoadBalancerPool, poolId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -277,6 +282,9 @@ func (a *EdgeGatewayLoadBalancerPoolApiService) UpdateLoadBalancerPool(ctx conte
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -305,4 +313,3 @@ func (a *EdgeGatewayLoadBalancerPoolApiService) UpdateLoadBalancerPool(ctx conte
 
 	return localVarHttpResponse, nil
 }
-

--- a/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_pools.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_pools.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -35,7 +34,7 @@ EdgeGatewayLoadBalancerPoolsApiService Creates a Load Balancer Pool.
 
 
 */
-func (a *EdgeGatewayLoadBalancerPoolsApiService) CreateLoadBalancerPool(ctx context.Context, loadBalancerPool EdgeLoadBalancerPool) (*http.Response, error) {
+func (a *EdgeGatewayLoadBalancerPoolsApiService) CreateLoadBalancerPool(ctx context.Context, loadBalancerPool EdgeLoadBalancerPool, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -82,6 +81,9 @@ func (a *EdgeGatewayLoadBalancerPoolsApiService) CreateLoadBalancerPool(ctx cont
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -133,7 +135,7 @@ type EdgeGatewayLoadBalancerPoolsApiGetPoolSummariesForGatewayOpts struct {
 	SortDesc optional.String
 }
 
-func (a *EdgeGatewayLoadBalancerPoolsApiService) GetPoolSummariesForGateway(ctx context.Context, page int32, pageSize int32, gatewayId string, localVarOptionals *EdgeGatewayLoadBalancerPoolsApiGetPoolSummariesForGatewayOpts) (EdgeLoadBalancerPoolSummaries, *http.Response, error) {
+func (a *EdgeGatewayLoadBalancerPoolsApiService) GetPoolSummariesForGateway(ctx context.Context, page int32, pageSize int32, gatewayId string, orgID string, localVarOptionals *EdgeGatewayLoadBalancerPoolsApiGetPoolSummariesForGatewayOpts) (EdgeLoadBalancerPoolSummaries, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -199,6 +201,9 @@ func (a *EdgeGatewayLoadBalancerPoolsApiService) GetPoolSummariesForGateway(ctx 
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_virtual_service.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_virtual_service.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -35,7 +34,7 @@ Delete a Virtual Service.
 
 
 */
-func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) DeleteVirtualService(ctx context.Context, virtualServiceId string) (*http.Response, error) {
+func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) DeleteVirtualService(ctx context.Context, virtualServiceId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -82,6 +81,9 @@ func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) DeleteVirtualService(c
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -119,7 +121,7 @@ Retrieves a specific Virtual Service.
 
 @return EdgeLoadBalancerVirtualService
 */
-func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) GetVirtualService(ctx context.Context, virtualServiceId string) (EdgeLoadBalancerVirtualService, *http.Response, error) {
+func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) GetVirtualService(ctx context.Context, virtualServiceId string, orgID string) (EdgeLoadBalancerVirtualService, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -165,6 +167,9 @@ func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) GetVirtualService(ctx 
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -220,7 +225,7 @@ Update a Virtual Service.
 
 
 */
-func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) UpdateVirtualService(ctx context.Context, virtualServiceConfig EdgeLoadBalancerVirtualService, virtualServiceId string) (*http.Response, error) {
+func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) UpdateVirtualService(ctx context.Context, virtualServiceConfig EdgeLoadBalancerVirtualService, virtualServiceId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -269,6 +274,9 @@ func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) UpdateVirtualService(c
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -297,4 +305,3 @@ func (a *EdgeGatewayLoadBalancerVirtualServiceApiService) UpdateVirtualService(c
 
 	return localVarHttpResponse, nil
 }
-

--- a/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_virtual_services_modified.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway_load_balancer_virtual_services_modified.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -36,7 +35,7 @@ Create a new Virtual Service for a specific Edge Gateway.
 
 
 */
-func (a *EdgeGatewayLoadBalancerVirtualServicesApiService) CreateVirtualService(ctx context.Context, virtualServiceConfig EdgeLoadBalancerVirtualService) (*http.Response, *GenericSwaggerError) {
+func (a *EdgeGatewayLoadBalancerVirtualServicesApiService) CreateVirtualService(ctx context.Context, virtualServiceConfig EdgeLoadBalancerVirtualService, orgID string) (*http.Response, *GenericSwaggerError) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -83,6 +82,9 @@ func (a *EdgeGatewayLoadBalancerVirtualServicesApiService) CreateVirtualService(
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -140,7 +142,7 @@ type EdgeGatewayLoadBalancerVirtualServicesApiGetVirtualServiceSummariesForGatew
 	SortDesc optional.String
 }
 
-func (a *EdgeGatewayLoadBalancerVirtualServicesApiService) GetVirtualServiceSummariesForGateway(ctx context.Context, page int32, pageSize int32, gatewayId string, localVarOptionals *EdgeGatewayLoadBalancerVirtualServicesApiGetVirtualServiceSummariesForGatewayOpts) (EdgeLoadBalancerVirtualServiceSummaries, *http.Response, error) {
+func (a *EdgeGatewayLoadBalancerVirtualServicesApiService) GetVirtualServiceSummariesForGateway(ctx context.Context, page int32, pageSize int32, gatewayId string, orgID string, localVarOptionals *EdgeGatewayLoadBalancerVirtualServicesApiGetVirtualServiceSummariesForGatewayOpts) (EdgeLoadBalancerVirtualServiceSummaries, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -206,6 +208,9 @@ func (a *EdgeGatewayLoadBalancerVirtualServicesApiService) GetVirtualServiceSumm
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/api_edge_gateway_nat_rule.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway_nat_rule.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -35,7 +34,7 @@ EdgeGatewayNatRuleApiService Deletes a specific NAT Rule configuration of the ed
 
 
 */
-func (a *EdgeGatewayNatRuleApiService) DeleteNatRule(ctx context.Context, gatewayId string, ruleId string) (*http.Response, error) {
+func (a *EdgeGatewayNatRuleApiService) DeleteNatRule(ctx context.Context, gatewayId string, ruleId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -82,6 +81,9 @@ func (a *EdgeGatewayNatRuleApiService) DeleteNatRule(ctx context.Context, gatewa
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -131,7 +133,7 @@ EdgeGatewayNatRuleApiService Retrieves a specific NAT Rule configuration of the 
 
 @return EdgeNatRule
 */
-func (a *EdgeGatewayNatRuleApiService) GetNatRule(ctx context.Context, gatewayId string, ruleId string) (EdgeNatRule, *http.Response, error) {
+func (a *EdgeGatewayNatRuleApiService) GetNatRule(ctx context.Context, gatewayId string, ruleId string, orgID string) (EdgeNatRule, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -178,6 +180,9 @@ func (a *EdgeGatewayNatRuleApiService) GetNatRule(ctx context.Context, gatewayId
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -244,7 +249,7 @@ EdgeGatewayNatRuleApiService Update a specific NAT Rule configuration of the edg
 
 
 */
-func (a *EdgeGatewayNatRuleApiService) UpdateNatRule(ctx context.Context, edgeNatRule EdgeNatRule, gatewayId string, ruleId string) (*http.Response, error) {
+func (a *EdgeGatewayNatRuleApiService) UpdateNatRule(ctx context.Context, edgeNatRule EdgeNatRule, gatewayId string, ruleId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -293,6 +298,9 @@ func (a *EdgeGatewayNatRuleApiService) UpdateNatRule(ctx context.Context, edgeNa
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/api_edge_gateway_nat_rules.go
+++ b/pkg/vcdswaggerclient/api_edge_gateway_nat_rules.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -36,7 +35,7 @@ EdgeGatewayNatRulesApiService Creates a NAT Rule on the Edge Gateway.
 
 
 */
-func (a *EdgeGatewayNatRulesApiService) CreateNatRule(ctx context.Context, edgeNatRule EdgeNatRule, gatewayId string) (*http.Response, error) {
+func (a *EdgeGatewayNatRulesApiService) CreateNatRule(ctx context.Context, edgeNatRule EdgeNatRule, gatewayId string, orgID string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -84,6 +83,9 @@ func (a *EdgeGatewayNatRulesApiService) CreateNatRule(ctx context.Context, edgeN
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -156,7 +158,7 @@ type EdgeGatewayNatRulesApiGetNatRulesOpts struct {
 	SortDesc optional.String
 }
 
-func (a *EdgeGatewayNatRulesApiService) GetNatRules(ctx context.Context, pageSize int32, gatewayId string, localVarOptionals *EdgeGatewayNatRulesApiGetNatRulesOpts) (EdgeNatRules, *http.Response, error) {
+func (a *EdgeGatewayNatRulesApiService) GetNatRules(ctx context.Context, pageSize int32, gatewayId string, orgID string, localVarOptionals *EdgeGatewayNatRulesApiGetNatRulesOpts) (EdgeNatRules, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -219,6 +221,9 @@ func (a *EdgeGatewayNatRulesApiService) GetNatRules(ctx context.Context, pageSiz
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -274,4 +279,3 @@ func (a *EdgeGatewayNatRulesApiService) GetNatRules(ctx context.Context, pageSiz
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
-

--- a/pkg/vcdswaggerclient/api_load_balancer_service_engine_group_assignments.go
+++ b/pkg/vcdswaggerclient/api_load_balancer_service_engine_group_assignments.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -41,7 +40,6 @@ func (a *LoadBalancerServiceEngineGroupAssignmentsApiService) CreateServiceEngin
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
-
 	)
 
 	// create path and map variables
@@ -99,10 +97,9 @@ func (a *LoadBalancerServiceEngineGroupAssignmentsApiService) CreateServiceEngin
 		return localVarHttpResponse, err
 	}
 
-
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 
@@ -132,7 +129,7 @@ type LoadBalancerServiceEngineGroupAssignmentsApiGetServiceEngineGroupAssignment
 	SortDesc optional.String
 }
 
-func (a *LoadBalancerServiceEngineGroupAssignmentsApiService) GetServiceEngineGroupAssignments(ctx context.Context, page int32, pageSize int32, localVarOptionals *LoadBalancerServiceEngineGroupAssignmentsApiGetServiceEngineGroupAssignmentsOpts) (LoadBalancerServiceEngineGroupAssignments, *http.Response, error) {
+func (a *LoadBalancerServiceEngineGroupAssignmentsApiService) GetServiceEngineGroupAssignments(ctx context.Context, page int32, pageSize int32, orgID string, localVarOptionals *LoadBalancerServiceEngineGroupAssignmentsApiGetServiceEngineGroupAssignmentsOpts) (LoadBalancerServiceEngineGroupAssignments, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -197,6 +194,9 @@ func (a *LoadBalancerServiceEngineGroupAssignmentsApiService) GetServiceEngineGr
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/api_org_vdc_network.go
+++ b/pkg/vcdswaggerclient/api_org_vdc_network.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -283,7 +282,7 @@ OrgVdcNetworkApiService Retrieves a specific Org vDC network.
 
 @return VdcNetwork
 */
-func (a *OrgVdcNetworkApiService) GetOrgVdcNetwork(ctx context.Context, vdcNetworkId string) (VdcNetwork, *http.Response, error) {
+func (a *OrgVdcNetworkApiService) GetOrgVdcNetwork(ctx context.Context, vdcNetworkId string, orgID string) (VdcNetwork, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -330,6 +329,9 @@ func (a *OrgVdcNetworkApiService) GetOrgVdcNetwork(ctx context.Context, vdcNetwo
 
 		}
 	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -348,7 +350,7 @@ func (a *OrgVdcNetworkApiService) GetOrgVdcNetwork(ctx context.Context, vdcNetwo
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 

--- a/pkg/vcdswaggerclient/api_org_vdc_networks.go
+++ b/pkg/vcdswaggerclient/api_org_vdc_networks.go
@@ -1,4 +1,3 @@
-
 /*
  * VMware Cloud Director OpenAPI
  *
@@ -40,7 +39,6 @@ func (a *OrgVdcNetworksApiService) CreateNetwork(ctx context.Context, vdcNetwork
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
-
 	)
 
 	// create path and map variables
@@ -107,7 +105,7 @@ func (a *OrgVdcNetworksApiService) CreateNetwork(ctx context.Context, vdcNetwork
 
 		if localVarHttpResponse.StatusCode == 400 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarHttpResponse, newErr
@@ -137,12 +135,12 @@ Get all Org vDC networks. If \&quot;ownerRef\&quot; property is not specified in
 */
 
 type OrgVdcNetworksApiGetAllVdcNetworksOpts struct {
-	Filter optional.String
-	SortAsc optional.String
+	Filter   optional.String
+	SortAsc  optional.String
 	SortDesc optional.String
 }
 
-func (a *OrgVdcNetworksApiService) GetAllVdcNetworks(ctx context.Context, page int32, pageSize int32, localVarOptionals *OrgVdcNetworksApiGetAllVdcNetworksOpts) (VdcNetworks, *http.Response, error) {
+func (a *OrgVdcNetworksApiService) GetAllVdcNetworks(ctx context.Context, orgID string, page int32, pageSize int32, localVarOptionals *OrgVdcNetworksApiGetAllVdcNetworksOpts) (VdcNetworks, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -207,6 +205,9 @@ func (a *OrgVdcNetworksApiService) GetAllVdcNetworks(ctx context.Context, page i
 			localVarHeaderParams["Authorization"] = key
 
 		}
+	}
+	if orgID != "" {
+		localVarHeaderParams[TenantContextHeader] = orgID
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/pkg/vcdswaggerclient/vcdconstants.go
+++ b/pkg/vcdswaggerclient/vcdconstants.go
@@ -1,0 +1,5 @@
+package swagger
+
+const (
+	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
+)


### PR DESCRIPTION
* Cloud api requests should be scoped to the cluster's organization.
* fixes bugs where a system administrator user sees inconsistent behavior where VCD resources outside the cluster organization is being accessed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/139)
<!-- Reviewable:end -->
