### PR TITLE
[VCDA-4632] Fix detection of duplicates logic in getOvdcNetwork by name

### DIFF
--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -119,10 +119,10 @@ func (gatewayManager *GatewayManager) getOVDCNetwork(ctx context.Context, networ
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if networkFound {
-				return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
-			}
 			if ovdcNetwork.Name == gatewayManager.NetworkName {
+				if networkFound {
+					return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
+				}
 				ovdcNetworkID = ovdcNetwork.Id
 				networkFound = true
 			}

--- a/pkg/vcdswaggerclient/api_certificate_library_modified.go
+++ b/pkg/vcdswaggerclient/api_certificate_library_modified.go
@@ -25,10 +25,6 @@ var (
 	_ context.Context
 )
 
-const (
-	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
-)
-
 type CertificateLibraryApiService service
 
 /*

--- a/pkg/vcdswaggerclient/vcdconstants.go
+++ b/pkg/vcdswaggerclient/vcdconstants.go
@@ -1,0 +1,5 @@
+package swagger
+
+const (
+	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
+)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>
* Error should only be thrown when there are networks with duplicate names within an org
* Create a separate go file to store Tenant context constant

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/140)
<!-- Reviewable:end -->
