### PR TITLE
VCDA-4775: Ignore specified appProtocol

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -595,7 +595,11 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 			Protocol:     strings.ToUpper(string(port.Protocol)),
 		}
 		if port.AppProtocol != nil && *port.AppProtocol != "" {
-			portDetailsList[idx].Protocol = strings.ToUpper(*port.AppProtocol)
+			switch strings.ToUpper(*port.AppProtocol) {
+			// allow override in case of known protocols such as HTTP/HTTPS/TCP which are directly supported in Avi
+			case "HTTP", "HTTPS", "TCP":
+				portDetailsList[idx].Protocol = strings.ToUpper(*port.AppProtocol)
+			}
 		}
 		if _, ok := portsMap[port.Port]; ok {
 			portDetailsList[idx].UseSSL = true


### PR DESCRIPTION
Use appProtocol only in case of HTTP/HTTPS/TCP so that:
1. services such as nginx that use the appProtocol can work well.
2. other services with unexpected appProtocol are allowed to pass through.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/162)
<!-- Reviewable:end -->
