### PR TITLE
[VCDA-4776] Fix to ensure EnsureLoadBalancerDeleted is called for failed loadbalancer creations

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -387,5 +387,5 @@ func (lb *LBManager) hasVcdResources(ctx context.Context, service *v1.Service) (
 			Protocol: string(port.Protocol),
 		}
 	}
-	return lb.vcdClient.HasVCDResources(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList)
+	return lb.vcdClient.VerifyVCDResourcesForApplicationLB(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList)
 }

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -196,7 +196,7 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 	// return nil for the status back to controller.
 	// In this case, we would need to check if there is any VCD resources, if so we can return true for 'exists' to controller to call EnsureLoadBalancerDeleted()
 	if !lbExists {
-		hasVcdResources, vcdResourceCheckErr := lb.verifyVCDResourcesForAppliationLB(ctx, service)
+		hasVcdResources, vcdResourceCheckErr := lb.verifyVCDResourcesForApplicationLB(ctx, service)
 		return nil, hasVcdResources, vcdResourceCheckErr
 	}
 
@@ -371,9 +371,9 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 	}, nil
 }
 
-// verifyVCDResourcesForAppliationLB checks for any CPI created components, such as virtual service, LB pool, and NAT rule refs for determining GetLoadBalancer()
+// verifyVCDResourcesForApplicationLB checks for any CPI created components, such as virtual service, LB pool, and NAT rule refs for determining GetLoadBalancer()
 // to be returned true for VCD resource clean up by the controller
-func (lb *LBManager) verifyVCDResourcesForAppliationLB (ctx context.Context, service *v1.Service) (bool, error) {
+func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, service *v1.Service) (bool, error) {
 	virtualServiceNamePrefix := lb.getVirtualServicePrefix(ctx, service)
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
 	klog.Infof("Checking VCD Resources with virtual service [%s] and lb pool [%s]", virtualServiceNamePrefix, lbPoolNamePrefix)

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -196,7 +196,7 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 	// return nil for the status back to controller.
 	// In this case, we would need to check if there is any VCD resources, if so we can return true for 'exists' to controller to call EnsureLoadBalancerDeleted()
 	if !lbExists {
-		hasVcdResources, vcdResourceCheckErr := lb.hasVcdResources(ctx, service)
+		hasVcdResources, vcdResourceCheckErr := lb.verifyVCDResourcesForAppliationLB(ctx, service)
 		return nil, hasVcdResources, vcdResourceCheckErr
 	}
 
@@ -371,9 +371,9 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 	}, nil
 }
 
-// hasVcdResources checks for any CPI created components, such as virtual service, LB pool, and NAT rule refs for determining GetLoadBalancer()
+// verifyVCDResourcesForAppliationLB checks for any CPI created components, such as virtual service, LB pool, and NAT rule refs for determining GetLoadBalancer()
 // to be returned true for VCD resource clean up by the controller
-func (lb *LBManager) hasVcdResources(ctx context.Context, service *v1.Service) (bool, error) {
+func (lb *LBManager) verifyVCDResourcesForAppliationLB (ctx context.Context, service *v1.Service) (bool, error) {
 	virtualServiceNamePrefix := lb.getVirtualServicePrefix(ctx, service)
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
 	klog.Infof("Checking VCD Resources with virtual service [%s] and lb pool [%s]", virtualServiceNamePrefix, lbPoolNamePrefix)

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -159,7 +159,6 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 			// if any lb that is expected is not created, return false to retry creation
 			return nil, false, nil
 		}
-		// If we've reached here, then there must've been at least 1 virtualIp belonging to a certain port in the service
 	}
 	if virtualIP == "" {
 		// this implies that no port was specified

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -1741,7 +1741,7 @@ func (client *Client) IsNSXTBackedGateway() bool {
 	return isNSXTBackedGateway
 }
 
-func (client *Client) HasVCDResources(ctx context.Context, virtualServiceNamePrefix string,
+func (client *Client) VerifyVCDResourcesForApplicationLB (ctx context.Context, virtualServiceNamePrefix string,
 	lbPoolNamePrefix string, portDetailsList []PortDetails) (bool, error) {
 	for _, portDetails := range portDetailsList {
 		if portDetails.InternalPort == 0 {

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -1751,7 +1751,6 @@ func (client *Client) VerifyVCDResourcesForApplicationLB (ctx context.Context, v
 		}
 		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portDetails.PortSuffix)
 		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portDetails.PortSuffix)
-		dnatRuleName := getDNATRuleName(virtualServiceName)
 
 		vsSummary, err := client.getVirtualService(ctx, virtualServiceName)
 		if err != nil {
@@ -1772,13 +1771,16 @@ func (client *Client) VerifyVCDResourcesForApplicationLB (ctx context.Context, v
 			return true, nil
 		}
 
-		dnatRuleRef, err := client.getNATRuleRef(ctx, dnatRuleName)
-		if err != nil {
-			return false, fmt.Errorf("error getting dnat rule ref for [%s]: [%v]", dnatRuleName, err)
-		}
-		if dnatRuleRef != nil {
-			klog.Infof("DNAT Rule Ref found: [%s]", lbPoolName)
-			return true, nil
+		if client.OneArm != nil {
+			dnatRuleName := getDNATRuleName(virtualServiceName)
+			dnatRuleRef, err := client.getNATRuleRef(ctx, dnatRuleName)
+			if err != nil {
+				return false, fmt.Errorf("error getting dnat rule ref for [%s]: [%v]", dnatRuleName, err)
+			}
+			if dnatRuleRef != nil {
+				klog.Infof("DNAT Rule Ref found: [%s]", lbPoolName)
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -1740,3 +1740,46 @@ func (client *Client) IsNSXTBackedGateway() bool {
 
 	return isNSXTBackedGateway
 }
+
+func (client *Client) HasVCDResources(ctx context.Context, virtualServiceNamePrefix string,
+	lbPoolNamePrefix string, portDetailsList []PortDetails) (bool, error) {
+	for _, portDetails := range portDetailsList {
+		if portDetails.InternalPort == 0 {
+			klog.Infof("No internal port specified for [%s], hence loadbalancer not created\n",
+				portDetails.PortSuffix)
+			continue
+		}
+		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portDetails.PortSuffix)
+		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portDetails.PortSuffix)
+		dnatRuleName := getDNATRuleName(virtualServiceName)
+
+		vsSummary, err := client.getVirtualService(ctx, virtualServiceName)
+		if err != nil {
+			return false, fmt.Errorf("error getting virtual service [%s]: [%v]", virtualServiceName, err)
+		}
+
+		if vsSummary != nil {
+			klog.Infof("Virtual Service found: [%s]", virtualServiceName)
+			return true, nil
+		}
+
+		lbPool, err := client.getLoadBalancerPool(ctx, lbPoolName)
+		if err != nil {
+			return false, fmt.Errorf("error getting loadbalancer pool for [%s]: [%v]", lbPoolName, err)
+		}
+		if lbPool != nil {
+			klog.Infof("Load balancer pool found: [%s]", lbPoolName)
+			return true, nil
+		}
+
+		dnatRuleRef, err := client.getNATRuleRef(ctx, dnatRuleName)
+		if err != nil {
+			return false, fmt.Errorf("error getting dnat rule ref for [%s]: [%v]", dnatRuleName, err)
+		}
+		if dnatRuleRef != nil {
+			klog.Infof("DNAT Rule Ref found: [%s]", lbPoolName)
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
* Ensure clean up of VCD resources even if loadbalancer fails to come up completely
* Tested with:
  * CSE 3.1.3 cluster - Install Ingress using helm without specifying any cert annotations and then deleting the service with helm uninstall
  * CSE 3.1.3 cluster - Install Ingress using helm and specifying invalid certificate and then deleting the service with helm uninstall
  * CSE 3.1.3 cluster - Install Ingress using helm and loadbalancer came up successfully, performed helm uninstall and cleanly deleted everything
  * CSE 3.1.3 cluster - Install ingress using helm and loadbalancer came up successfully, performed helm uninstall and forced it to fail by updating LB components at the same time to force busy error, saw it reconcile and delete remainder resources.

Signed-off-by: lzichong <lzichong@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/166)
<!-- Reviewable:end -->
