### PR TITLE
[VCDA-4885] Create schema definition for CPI status section in capvcdCluter RDE

### DIFF
--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -1,0 +1,42 @@
+{
+  "components": {
+    "cpi": {
+      "type": "object",
+      "description": "schema for the CPI status section in capvcdCluster defined entity.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the CPI component"
+        },
+        "version": {
+          "type": "string",
+          "description": "version of the CPI used"
+        },
+        "eventSet": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {}
+          },
+          "description": "list of most recent events from CPI"
+        },
+        "vcdResourceSet": {
+          "type": "array",
+          "description": "list of VCD resources created by CPI. Virtual IP for the ALB created by CPI will be part of additionalDetails section of the 'virtual-service' resource.",
+          "items": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "errorSet": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
* Created schema_1_1_0.json definition for CPI status section in CAPVCD cluster RDE
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/174)
<!-- Reviewable:end -->
