### PR TITLE
[VKCI-70] Fix to ensure VCD resources are cleaned up after deleting LB service even if LB failed during deployment

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -360,7 +360,9 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 			// as there is an error check first. If there is an error, the controller will return the delete operation immediately and will not continue to indicate lb has been deleted.
 			// Only if there is no error then it will check if hasVcdResource (lbExists), and if it exists, then it will ensure the deletion.
 			hasVcdResources, vcdResourceCheckErr := lb.VerifyVCDResourcesForApplicationLB(ctx, service)
-			klog.Errorf("error occurred while checking vcd resource for application LB in GetLoadBalancer: [%v]", vcdResourceCheckErr)
+			if vcdResourceCheckErr != nil {
+				klog.Errorf("error occurred while checking vcd resource for application LB in GetLoadBalancer: [%v]", vcdResourceCheckErr)
+			}
 			return nil, hasVcdResources, vcdResourceCheckErr
 		}
 	}

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -735,7 +735,7 @@ func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, vir
 				return false, fmt.Errorf("error getting dnat rule ref for [%s]: [%v] during VCD resources verification", dnatRuleName, err)
 			}
 			if dnatRuleRef != nil {
-				klog.Infof("DNAT Rule Ref found: [%s]", lbPoolName)
+				klog.Infof("DNAT Rule Ref found: [%s]", dnatRuleName)
 				return true, nil
 			}
 			appPortProfileName := vcdsdk.GetAppPortProfileName(dnatRuleName)

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -706,7 +706,7 @@ func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, vir
 		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portDetails.PortSuffix)
 		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portDetails.PortSuffix)
 
-		// GetVirtualService() will always return 1 virtual service named virtualServiceName, as VCD doesn't allow duplicate VS names.
+		// GetVirtualService() will always look for 1 virtual service named virtualServiceName, as VCD doesn't allow duplicate VS names.
 		// In the event where a virtual service name is not found in GetVirtualService(), it will return nil for both error and vsSummary.
 		vsSummary, err := gatewayMgr.GetVirtualService(ctx, virtualServiceName)
 		if err != nil {

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -688,8 +688,7 @@ func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, vir
 
 	for _, portDetails := range portDetailsList {
 		if portDetails.InternalPort == 0 {
-			klog.Infof("No internal port specified for [%s], hence loadbalancer not created\n",
-				portDetails.PortSuffix)
+			klog.Infof("No internal port specified for [%s], hence loadbalancer not created", portDetails.PortSuffix)
 			continue
 		}
 		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portDetails.PortSuffix)
@@ -697,7 +696,7 @@ func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, vir
 
 		vsSummary, err := gatewayMgr.GetVirtualService(ctx, virtualServiceNamePrefix)
 		if err != nil {
-			return false, fmt.Errorf("error getting virtual service [%s]: [%v]", virtualServiceName, err)
+			return false, fmt.Errorf("error getting virtual service [%s]: [%v] during VCD resources verification", virtualServiceName, err)
 		}
 
 		if vsSummary != nil {
@@ -707,7 +706,7 @@ func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, vir
 
 		lbPool, err := gatewayMgr.GetLoadBalancerPool(ctx, lbPoolName)
 		if err != nil {
-			return false, fmt.Errorf("error getting loadbalancer pool for [%s]: [%v]", lbPoolName, err)
+			return false, fmt.Errorf("error getting loadbalancer pool for [%s]: [%v] during VCD resources verification", lbPoolName, err)
 		}
 		if lbPool != nil {
 			klog.Infof("Load balancer pool found: [%s]", lbPoolName)
@@ -718,7 +717,7 @@ func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, vir
 			dnatRuleName := vcdsdk.GetDNATRuleName(virtualServiceName)
 			dnatRuleRef, err := gatewayMgr.GetNATRuleRef(ctx, dnatRuleName)
 			if err != nil {
-				return false, fmt.Errorf("error getting dnat rule ref for [%s]: [%v]", dnatRuleName, err)
+				return false, fmt.Errorf("error getting dnat rule ref for [%s]: [%v] during VCD resources verification", dnatRuleName, err)
 			}
 			if dnatRuleRef != nil {
 				klog.Infof("DNAT Rule Ref found: [%s]", lbPoolName)

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -300,7 +300,7 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 				klog.Errorf("unable to add CPI error [%s] to RDE [%s], [%v]", cpisdk.GetLoadbalancerError, lb.clusterID, addToErrorSetErr)
 			}
 			return nil, nil,
-				fmt.Errorf("unable to get virtual service summary for [%s]: [%v]",
+				fmt.Errorf("unable to get load balancer information for the service [%s]: [%v]",
 					virtualServiceName, err)
 		}
 		removeErr := cpiRdeManager.RDEManager.RemoveErrorByNameOrIdFromErrorSet(ctx, vcdsdk.ComponentCPI, cpisdk.GetLoadbalancerError, "", virtualServiceName)
@@ -354,6 +354,7 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 			// If we have an empty IP for a specific port, there may be resources allocated in other ports so we will do resource check to return for delete.
 			// As if there is vcd resources, we should return a nil status, but true for lb exists to the controller to pick up for deletion.
 			hasVcdResources, vcdResourceCheckErr := lb.VerifyVCDResourcesForApplicationLB(ctx, service)
+			klog.Errorf("error occurred while checking vcd resource for application LB in GetLoadBalancer: [%v]", vcdResourceCheckErr)
 			return nil, hasVcdResources, vcdResourceCheckErr
 		}
 	}

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -357,7 +357,7 @@ func (lb *LBManager) GetLoadBalancer(ctx context.Context, clusterName string,
 			// As if there is vcd resources, we should return a nil status, but true for lb exists to the controller to pick up for deletion.
 
 			// In the event we do get an actual vcdResourceCheck error, then hasVcdResource (lbExists) may be false. The controller will return and reconcile
-			// as there is an error check first. If there is an error, the controller will return the delete operation immediately and continue to indicate lb has been deleted.
+			// as there is an error check first. If there is an error, the controller will return the delete operation immediately and will not continue to indicate lb has been deleted.
 			// Only if there is no error then it will check if hasVcdResource (lbExists), and if it exists, then it will ensure the deletion.
 			hasVcdResources, vcdResourceCheckErr := lb.VerifyVCDResourcesForApplicationLB(ctx, service)
 			klog.Errorf("error occurred while checking vcd resource for application LB in GetLoadBalancer: [%v]", vcdResourceCheckErr)


### PR DESCRIPTION
* Testings done:
Attempt LB deployment with invalid configurations which causes the load balancer to never come up, and then performing a delete and saw the VCD resources get cleaned up.

Signed-off-by: lzichong <lzichong@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/179)
<!-- Reviewable:end -->
