### PR TITLE
[VKCI-98] Fix for nodes not being deleted due to VM not found after deleted in VCD

### DIFF
--- a/pkg/vcdsdk/vapp.go
+++ b/pkg/vcdsdk/vapp.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	trueVar     = true
-	falseVar    = false
+	trueVar  = true
+	falseVar = false
 )
 
 type VdcManager struct {
@@ -346,6 +346,11 @@ func (vdc *VdcManager) FindVMByUUID(VAppName string, vcdVmUUID string) (*govcd.V
 
 	vm, err := vApp.GetVMById(vmUUID, true)
 	if err != nil {
+		// CPI uses this function via vminfocache which finds VmInfo by using GetByUUID() which calls FindVMByUUID().
+		// In CPI, we are handling ErrorEntityNotFound case, but we were not returning it so it skipped this case causing nodes to not get deleted as it was not found.
+		if err == govcd.ErrorEntityNotFound {
+			return nil, govcd.ErrorEntityNotFound
+		}
 		return nil, fmt.Errorf("unable to find vm UUID [%s] in vApp [%s]: [%v]",
 			vmUUID, VAppName, err)
 	}


### PR DESCRIPTION
Tested via automation testing by deleting a VM in VCD and observed that the Node in Kubernetes cluster was deleted.

CAPVCD, Projector, VCDKE repo doesn't seem to be using this method so other projects shouldn't need changes once common core updates

Error reference: https://github.com/vmware/cloud-provider-for-cloud-director/blob/main/pkg/ccm/instances.go#L171

Signed-off-by: lzichong <lzichong@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/186)
<!-- Reviewable:end -->
