### PR TITLE
VKCI-97: Add annotation to skip Avi SSL termination for all protocols

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -636,6 +636,7 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 
 	// allow users to terminate SSL by other means
 	skipAviSSLTermination := shouldSkipAviSSLTermination(service)
+	klog.Infof("Annotation [%s] set to [%v]", skipAviSSLTerminationAnnotation, skipAviSSLTermination)
 	if skipAviSSLTermination {
 		certAlias = ""
 	}


### PR DESCRIPTION
CPI uses the appProtocol feature and tries to do some intelligent things such as set up Avi with HTTPS and a Cert in case the appProtocol is `https`.
Nginx has an `appProtocol: false` option by means of which one can control the `appProtocol`.
However this option is not yet available in ingresses such as Contour.

So we introduce a new annotation (`service.beta.kubernetes.io/vcloud-avi-ssl-no-termination`) to let CPI provide the same effect as disabling `appProtocol`. When this annotation is set to `"true"`, CPI will create a TCP LoadBalancer in Avi with the port. The expectation is that SSL termination will be provided by the ingress such as Contour / Nginx

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/197)
<!-- Reviewable:end -->
