### PR TITLE
[VKCI-104] Fix for nil pointer exception when subnet is null from usage of IP Spaces

### DIFF
--- a/pkg/vcdsdk/ipam.go
+++ b/pkg/vcdsdk/ipam.go
@@ -59,7 +59,7 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 	for _, edgeGWUplink := range edgeGW.EdgeGatewayUplinks {
 		// A nil check is needed for edgeGWUplink.Subnet because there is a possibility for subnet to be null which can cause CCM pod to crash.
 		// An example is the usage of IP Spaces which is in VCD 10.4.1.
-		if edgeGWUplink.Subnets != nil {
+		if edgeGWUplink.Subnets == nil {
 			continue
 		}
 		for _, subnet := range edgeGWUplink.Subnets.Values {

--- a/pkg/vcdsdk/ipam.go
+++ b/pkg/vcdsdk/ipam.go
@@ -57,6 +57,11 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 
 	ipRangeList := make([]IPRange, 0)
 	for _, edgeGWUplink := range edgeGW.EdgeGatewayUplinks {
+		// A nil check is needed for edgeGWUplink.Subnet because there is a possibility for subnet to be null which can cause CCM pod to crash.
+		// An example is the usage of IP Spaces which is in VCD 10.4.1.
+		if edgeGWUplink.Subnets != nil {
+			continue
+		}
 		for _, subnet := range edgeGWUplink.Subnets.Values {
 			if subnet.IpRanges == nil {
 				continue


### PR DESCRIPTION
Tested against VCD 10.4.1 GA using IP Spaces. Verified that CCM pod is no longer crashing when IP's can't be fetched:

E1222 01:39:59.854969       1 controller.go:307] error processing service default/ingress-nginx-controller (will retry): failed to ensure load balancer: unable to create loadbalancer for ports [[]vcdsdk.PortDetails{vcdsdk.PortDetails{Protocol:"HTTP", PortSuffix:"http", ExternalPort:80, InternalPort:30096, UseSSL:false, CertAlias:""}, vcdsdk.PortDetails{Protocol:"HTTPS", PortSuffix:"https", ExternalPort:443, InternalPort:32018, UseSSL:false, CertAlias:""}}]: [unable to get unused IP address from subnet []: [unable to get any ipRanges in gateway]]

Previously, the CCM pod would crash due to using Subnet.Values when it is null.

Signed-off-by: lzichong <lzichong@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/198)
<!-- Reviewable:end -->
