### PR TITLE
[VKCI-104] Cherrypick - Fix for nil pointer exception when subnet is null from IP Spaces Usage

### DIFF
--- a/pkg/vcdsdk/ipam.go
+++ b/pkg/vcdsdk/ipam.go
@@ -57,6 +57,11 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 
 	ipRangeList := make([]IPRange, 0)
 	for _, edgeGWUplink := range edgeGW.EdgeGatewayUplinks {
+		// A nil check is needed for edgeGWUplink.Subnet because there is a possibility for subnet to be null which can cause CCM pod to crash.
+		// An example is the usage of IP Spaces which is in VCD 10.4.1.
+		if edgeGWUplink.Subnets == nil {
+			continue
+		}
 		for _, subnet := range edgeGWUplink.Subnets.Values {
 			if subnet.IpRanges == nil {
 				continue

--- a/pkg/vcdsdk/ipam.go
+++ b/pkg/vcdsdk/ipam.go
@@ -57,11 +57,6 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 
 	ipRangeList := make([]IPRange, 0)
 	for _, edgeGWUplink := range edgeGW.EdgeGatewayUplinks {
-		// A nil check is needed for edgeGWUplink.Subnet because there is a possibility for subnet to be null which can cause CCM pod to crash.
-		// An example is the usage of IP Spaces which is in VCD 10.4.1.
-		if edgeGWUplink.Subnets == nil {
-			continue
-		}
 		for _, subnet := range edgeGWUplink.Subnets.Values {
 			if subnet.IpRanges == nil {
 				continue


### PR DESCRIPTION
…ge of IP Spaces (#198)

* Fix for nil pointer exception when IP Spaces is being used resulting in null subnet

Signed-off-by: lzichong <lzichong@vmware.com>

* CR of Aniruddh: correction for nil check

Signed-off-by: lzichong <lzichong@vmware.com>

Signed-off-by: lzichong <lzichong@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/199)
<!-- Reviewable:end -->
