### PR TITLE
Set ComputerName as vmName

### DIFF
--- a/pkg/vcdsdk/vapp.go
+++ b/pkg/vcdsdk/vapp.go
@@ -653,6 +653,7 @@ func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, v
 						AdminPasswordEnabled:  &trueVar,
 						AdminPasswordAuto:     &trueVar,
 						ResetPasswordRequired: &falseVar,
+						ComputerName:          vmName,
 					},
 					NetworkConnectionSection: &types.NetworkConnectionSection{
 						NetworkConnection: []*types.NetworkConnection{


### PR DESCRIPTION
Some users' naming policies enforce that the computer name matches the VM name.
This is also the default behavior in the VCD UI when provisioning a VM.
This PR replicates the default policy and sets the VM computerName field to the same values as the VM name.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/219)
<!-- Reviewable:end -->
