### PR TITLE
Update cloud-provider-for-cloud-director version

### DIFF
--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:main-branch.8946fef
+          image: harbor-repo.vmware.com/vcloud/cloud-provider-for-cloud-director:1.3.0
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director


### PR DESCRIPTION
Fixes https://github.com/vmware/cloud-provider-for-cloud-director/issues/238
* TLDR
`vmware-cloud-director-ccm` deployment is breaking since yesterday.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/239)
<!-- Reviewable:end -->
