### PR TITLE
fix: update tolerations

### DIFF
--- a/manifests/cloud-director-ccm-crs.yaml
+++ b/manifests/cloud-director-ccm-crs.yaml
@@ -180,12 +180,14 @@ spec:
           operator: "Exists"
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: node-role.kubernetes.io/master
+                - key: node-role.kubernetes.io/control-plane
                   operator: "Exists"
       volumes:
         - name: vcloud-ccm-config-volume

--- a/manifests/cloud-director-ccm-crs.yaml.template
+++ b/manifests/cloud-director-ccm-crs.yaml.template
@@ -180,12 +180,14 @@ spec:
           operator: "Exists"
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: node-role.kubernetes.io/master
+                - key: node-role.kubernetes.io/control-plane
                   operator: "Exists"
       volumes:
         - name: vcloud-ccm-config-volume

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -174,12 +174,14 @@ spec:
           operator: "Exists"
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: node-role.kubernetes.io/master
+                - key: node-role.kubernetes.io/control-plane
                   operator: "Exists"
       volumes:
         - name: vcloud-ccm-config-volume

--- a/manifests/cloud-director-ccm.yaml.template
+++ b/manifests/cloud-director-ccm.yaml.template
@@ -174,12 +174,14 @@ spec:
           operator: "Exists"
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: node-role.kubernetes.io/master
+                - key: node-role.kubernetes.io/control-plane
                   operator: "Exists"
       volumes:
         - name: vcloud-ccm-config-volume


### PR DESCRIPTION
- Update tolerations and node affinity selector key as `node-role.kubernetes.io/master` has been deprecated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/240)
<!-- Reviewable:end -->
