### PR TITLE
[VKCI-159][VKCI-161] add common functions to common testing core

### DIFF
--- a/pkg/testingsdk/client.go
+++ b/pkg/testingsdk/client.go
@@ -194,6 +194,17 @@ func (tc *TestClient) GetWorkerNodes(ctx context.Context) ([]apiv1.Node, error) 
 	return wnPool, nil
 }
 
+func (tc *TestClient) GetNodes(ctx context.Context) ([]apiv1.Node, error) {
+	nPool, err := getNodes(ctx, tc.Cs.(*kubernetes.Clientset))
+	if err != nil {
+		if err == ResourceNotFound {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting Node Pool for cluster [%s(%s)]: [%v]", tc.ClusterName, tc.ClusterId, err)
+	}
+	return nPool, nil
+}
+
 func (tc *TestClient) GetStorageClass(ctx context.Context, scName string) (*stov1.StorageClass, error) {
 	sc, err := getStorageClass(ctx, tc.Cs.(*kubernetes.Clientset), scName)
 	if err != nil {

--- a/pkg/testingsdk/client.go
+++ b/pkg/testingsdk/client.go
@@ -10,6 +10,7 @@ import (
 	stov1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -262,6 +263,10 @@ func (tc *TestClient) GetService(ctx context.Context, nameSpace string, serviceN
 
 func (tc *TestClient) GetConfigMap(namespace, name string) (*apiv1.ConfigMap, error) {
 	return tc.Cs.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (tc *TestClient) GetK8sVersion() (*version.Info, error) {
+	return tc.Cs.(*kubernetes.Clientset).Discovery().ServerVersion()
 }
 
 func (tc *TestClient) GetIpamSubnetFromConfigMap(cm *apiv1.ConfigMap) (string, error) {

--- a/pkg/testingsdk/k8sclient.go
+++ b/pkg/testingsdk/k8sclient.go
@@ -331,6 +331,18 @@ func getWorkerNodes(ctx context.Context, k8sClient *kubernetes.Clientset) ([]api
 	return workerNodes, nil
 }
 
+func getNodes(ctx context.Context, k8sClient *kubernetes.Clientset) ([]apiv1.Node, error) {
+	var allNodes []apiv1.Node
+	nodes, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return allNodes, fmt.Errorf("error occurred while getting nodes")
+	}
+	for _, node := range nodes.Items {
+		allNodes = append(allNodes, node)
+	}
+	return allNodes, nil
+}
+
 func createStorageClass(ctx context.Context, k8sClient *kubernetes.Clientset, scName string, reclaimPolicy apiv1.PersistentVolumeReclaimPolicy, storageProfile string) (*stov1.StorageClass, error) {
 	if scName == "" {
 		return nil, ResourceNameNull
@@ -532,9 +544,9 @@ func createLoadBalancerService(ctx context.Context, k8sClient *kubernetes.Client
 			Labels:      labels,
 		},
 		Spec: apiv1.ServiceSpec{
-			Ports:    servicePort,
-			Selector: labels,
-			Type:     "LoadBalancer",
+			Ports:          servicePort,
+			Selector:       labels,
+			Type:           "LoadBalancer",
 			LoadBalancerIP: loadBalancerIP,
 		},
 	}

--- a/pkg/testingsdk/vcd_utils.go
+++ b/pkg/testingsdk/vcd_utils.go
@@ -45,17 +45,17 @@ func GetVappTemplates(client *vcdsdk.Client) ([]*types.QueryResultVappTemplateTy
 	}
 	catalogRecords, err := clusterOrg.QueryCatalogList()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving catalog records: [%v]", err)
+		return nil, fmt.Errorf("error retrieving catalog records from org: [%s]: [%v]", clusterOrg.Org.Name, err)
 	}
 	for _, catalogRecord := range catalogRecords {
 		catalog, err := clusterOrg.GetCatalogByName(catalogRecord.Name, true)
 		if err != nil {
-			return nil, fmt.Errorf("error retreiving catalog %s: [%v]", catalogRecord.Name, err)
+			return nil, fmt.Errorf("error retreiving catalog [%s] from org [%s]: [%v]", catalogRecord.Name, clusterOrg.Org.Name, err)
 		}
 
 		vappTemplates, err := catalog.QueryVappTemplateList()
 		if err != nil {
-			return nil, fmt.Errorf("error retreiving vApp templates from catalog %s: [%v]", catalogRecord.Name, err)
+			return nil, fmt.Errorf("error retreiving vApp templates from catalog [%s] from org [%s]: [%v]", catalogRecord.Name, clusterOrg.Org.Name, err)
 		}
 
 		// It is possible that users have uploaded the same vApp templates to

--- a/pkg/testingsdk/vcd_utils.go
+++ b/pkg/testingsdk/vcd_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	swagger "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func getTestVCDClient(params *VCDAuthParams) (*vcdsdk.Client, error) {
@@ -33,4 +34,33 @@ func getRdeById(ctx context.Context, client *vcdsdk.Client, rdeId string) (*swag
 		return nil, fmt.Errorf("error retrieving RDE [%s]: [%v]", rdeId, err)
 	}
 	return &rde, nil
+}
+
+func GetVappTemplates(client *vcdsdk.Client) ([]*types.QueryResultVappTemplateType, error) {
+	var allVappTemplates []*types.QueryResultVappTemplateType
+
+	clusterOrg, err := client.VCDClient.GetOrgByName(client.ClusterOrgName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving org [%s]: [%v]", client.ClusterOrgName, err)
+	}
+	catalogRecords, err := clusterOrg.QueryCatalogList()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving catalog records: [%v]", err)
+	}
+	for _, catalogRecord := range catalogRecords {
+		catalog, err := clusterOrg.GetCatalogByName(catalogRecord.Name, true)
+		if err != nil {
+			return nil, fmt.Errorf("error retreiving catalog %s: [%v]", catalogRecord.Name, err)
+		}
+
+		vappTemplates, err := catalog.QueryVappTemplateList()
+		if err != nil {
+			return nil, fmt.Errorf("error retreiving vApp templates from catalog %s: [%v]", catalogRecord.Name, err)
+		}
+
+		for _, vappTemplate := range vappTemplates {
+			allVappTemplates = append(allVappTemplates, vappTemplate)
+		}
+	}
+	return allVappTemplates, nil
 }

--- a/pkg/testingsdk/vcd_utils.go
+++ b/pkg/testingsdk/vcd_utils.go
@@ -58,6 +58,9 @@ func GetVappTemplates(client *vcdsdk.Client) ([]*types.QueryResultVappTemplateTy
 			return nil, fmt.Errorf("error retreiving vApp templates from catalog %s: [%v]", catalogRecord.Name, err)
 		}
 
+		// It is possible that users have uploaded the same vApp templates to
+		// multiple catalogs, so it is possible that there are duplicate vApp
+		// templates in `allVappTemplates`
 		for _, vappTemplate := range vappTemplates {
 			allVappTemplates = append(allVappTemplates, vappTemplate)
 		}


### PR DESCRIPTION
### Functions Implemented: 
- query vApp templates from all catalogs
- get all nodes (including control plane)
- get current cluster's k8s version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/243)
<!-- Reviewable:end -->
