### PR TITLE
[VKCI-162] common testing core - updated getNodes() and getWorkerNodes() error messages

### DIFF
--- a/pkg/testingsdk/k8sclient.go
+++ b/pkg/testingsdk/k8sclient.go
@@ -320,7 +320,7 @@ func getWorkerNodes(ctx context.Context, k8sClient *kubernetes.Clientset) ([]api
 	var workerNodes []apiv1.Node
 	nodes, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return workerNodes, fmt.Errorf("error occurred while getting nodes")
+		return workerNodes, fmt.Errorf("error occurred while getting nodes: [%v]", err)
 	}
 	for _, node := range nodes.Items {
 		_, ok := node.Labels[ControlPlaneLabel]
@@ -335,7 +335,7 @@ func getNodes(ctx context.Context, k8sClient *kubernetes.Clientset) ([]apiv1.Nod
 	var allNodes []apiv1.Node
 	nodes, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return allNodes, fmt.Errorf("error occurred while getting nodes")
+		return allNodes, fmt.Errorf("error occurred while getting nodes: [%v]", err)
 	}
 	for _, node := range nodes.Items {
 		allNodes = append(allNodes, node)


### PR DESCRIPTION
changed error messages from `fmt.Errorf("error occurred while getting nodes")` to `fmt.Errorf("error occurred while getting nodes: [%v]", err)` so we can see the list of errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/245)
<!-- Reviewable:end -->
