### PR TITLE
[VKCI-181] Move namespace/deployment creation inside the test spec to prevent duplicate namespace creation during tests

### DIFF
--- a/tests/e2e/loadbalancer_test.go
+++ b/tests/e2e/loadbalancer_test.go
@@ -31,7 +31,6 @@ var _ = Describe("Ensure Loadbalancer", func() {
 		err         error
 		ipamSubnet  string
 		networkName string
-		ovdcName    string
 		tc          *testingsdk.TestClient
 	)
 
@@ -53,12 +52,6 @@ var _ = Describe("Ensure Loadbalancer", func() {
 	}}
 
 	ctx := context.TODO()
-	ns, err = tc.CreateNameSpace(ctx, testBaseName)
-	Expect(err).NotTo(HaveOccurred())
-
-	// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
-	_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
-	Expect(err).NotTo(HaveOccurred())
 
 	// GetConfigMap to retrieve ipamSubnet, network name for gateway manager in order to check if VCD resources are present
 	ccmConfigMap, err := tc.GetConfigMap("kube-system", ccmConfigMapName)
@@ -85,6 +78,12 @@ var _ = Describe("Ensure Loadbalancer", func() {
 	It("should create a load balancer service", func() {
 		// Similar to Ingress setup, we will use: name=http, port=80, protocol=tcp, appProtocol=http
 		By("creating a http load balancer service")
+		ns, err = tc.CreateNameSpace(ctx, testBaseName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
+		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
+		Expect(err).NotTo(HaveOccurred())
 		svc, err = tc.CreateLoadBalancerService(ctx, ns.Name, testServiceName, nil, labels, httpServicePort, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc).NotTo(BeNil())
@@ -193,12 +192,6 @@ var _ = Describe("Ensure load balancer with user specified LB IP", func() {
 	}}
 
 	ctx := context.TODO()
-	ns, err = tc.CreateNameSpace(ctx, testBaseName)
-	Expect(err).NotTo(HaveOccurred())
-
-	// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
-	_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
-	Expect(err).NotTo(HaveOccurred())
 
 	// GetConfigMap to retrieve ipamSubnet, network name for gateway manager in order to check if VCD resources are present
 	ccmConfigMap, err := tc.GetConfigMap("kube-system", ccmConfigMapName)
@@ -228,6 +221,13 @@ var _ = Describe("Ensure load balancer with user specified LB IP", func() {
 	It("should create a load balancer service", func() {
 		// Similar to Ingress setup, we will use: name=http, port=80, protocol=tcp, appProtocol=http
 		By("creating a http load balancer service")
+		ns, err = tc.CreateNameSpace(ctx, testBaseName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
+		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
+		Expect(err).NotTo(HaveOccurred())
+
 		svc, err = tc.CreateLoadBalancerService(ctx, ns.Name, testServiceName, nil, labels, httpServicePort, explicitIP)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc).NotTo(BeNil())


### PR DESCRIPTION
* Move namespace/deployment creation inside the test spec to prevent duplicate namespace creation during tests
* Ensured tests are able to run without any issues/modifications

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/253)
<!-- Reviewable:end -->
