### PR TITLE
update tolerations in the artifacts

### DIFF
--- a/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
+++ b/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
@@ -180,12 +180,14 @@ spec:
           operator: "Exists"
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node-role.kubernetes.io/master
+                  - key: node-role.kubernetes.io/control-plane
                     operator: "Exists"
       volumes:
         - name: vcloud-ccm-config-volume


### PR DESCRIPTION
- update tolerations and node affinity for CRS templates in artifact as `node-role.kubernetes.io/master` is deprecated.