### PR TITLE
fix: move to scratch image and static binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,19 @@ ADD . /go/src/github.com/vmware/cloud-provider-for-cloud-director
 WORKDIR /go/src/github.com/vmware/cloud-provider-for-cloud-director
 
 ENV GOPATH /go
-RUN ["make", "build-within-docker"]
+RUN make build-within-docker && \
+    chmod +x /build/vcloud/cloud-provider-for-cloud-director
 
 ########################################################
 
-FROM photonos-docker-local.artifactory.eng.vmware.com/photon4:4.0-GA
+FROM scratch
 
 WORKDIR /opt/vcloud/bin
 
-COPY --from=builder /go/src/github.com/vmware/cloud-provider-for-cloud-director/LICENSE.txt .
-COPY --from=builder /go/src/github.com/vmware/cloud-provider-for-cloud-director/NOTICE.txt .
-COPY --from=builder /go/src/github.com/vmware/cloud-provider-for-cloud-director/open_source_license.txt .
+# copy multiple files at a time to create a single layer
+COPY --from=builder /go/src/github.com/vmware/cloud-provider-for-cloud-director/LICENSE.txt /go/src/github.com/vmware/cloud-provider-for-cloud-director/NOTICE.txt /go/src/github.com/vmware/cloud-provider-for-cloud-director/open_source_license.txt .
 COPY --from=builder /build/vcloud/cloud-provider-for-cloud-director .
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-RUN chmod +x /opt/vcloud/bin/cloud-provider-for-cloud-director
-
-USER nobody
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+USER 65534
+ENTRYPOINT ["/opt/vcloud/bin/cloud-provider-for-cloud-director"]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ crs-artifacts-dev:
 
 build-within-docker: vendor
 	mkdir -p /build/cloud-provider-for-cloud-director
-	go build -ldflags "-X github.com/vmware/cloud-provider-for-cloud-director/version.Version=$(version)" -o /build/vcloud/cloud-provider-for-cloud-director cmd/ccm/main.go
+	CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-provider-for-cloud-director/version.Version=$(version)" -o /build/vcloud/cloud-provider-for-cloud-director cmd/ccm/main.go
 
 ccm: $(GO_CODE)
 	docker build -f Dockerfile . -t cloud-provider-for-cloud-director:$(version)


### PR DESCRIPTION
- Move to a static binary and remove symbols

```bash
67 MB  COPY /build/vcloud/cloud-provider-for-cloud-director . # buildkit
```

```bash
47 MB  COPY /build/vcloud/cloud-provider-for-cloud-director . # buildkit
```

- Move from Photon 4 base to scratch image

```bash
after                    latest            98c2e649c766   5 minutes ago       47.4MB
before                   latest            f499247c66d9   8 minutes ago       170MB

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/255)
<!-- Reviewable:end -->
