### PR TITLE
[VCDA-5806] Ensure airgapped containers and binary images have same tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ crs-artifacts-dev:
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" artifacts/default-cloud-director-ccm-crs-airgap.yaml.template > artifacts/cloud-director-ccm-crs-airgap.yaml.template
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/dependencies.txt.template > artifacts/dependencies.txt
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/bom.json.template > artifacts/bom.json
-	docker build -f ./artifacts/Dockerfile . -t cpi-crs-airgapped:$(GITCOMMIT)
-	docker tag cpi-crs-airgapped:$(GITCOMMIT) $(REGISTRY)/cpi-crs-airgapped:$(GITCOMMIT)
-	docker push $(REGISTRY)/cpi-crs-airgapped:$(GITCOMMIT)
+	docker build -f ./artifacts/Dockerfile . -t cpi-crs-airgapped:$(version).$(GITCOMMIT)
+	docker tag cpi-crs-airgapped:$(version).$(GITCOMMIT) $(REGISTRY)/cpi-crs-airgapped:$(version).$(GITCOMMIT)
+	docker push $(REGISTRY)/cpi-crs-airgapped:$(version).$(GITCOMMIT)
 
 build-within-docker: vendor
 	mkdir -p /build/cloud-provider-for-cloud-director

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ REGISTRY?="projects-stg.registry.vmware.com/vmware-cloud-director"
 .PHONY: build-within-docker vendor
 
 crs-artifacts-prod:
-	sed -e "s/\.__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" artifacts/default-cloud-director-ccm-crs-airgap.yaml.template > artifacts/cloud-director-ccm-crs-airgap.yaml.template
-	sed -e "s/\.__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/dependencies.txt.template > artifacts/dependencies.txt
-	sed -e "s/\.__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/bom.json.template > artifacts/bom.json
+	sed -e "s/\-__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" artifacts/default-cloud-director-ccm-crs-airgap.yaml.template > artifacts/cloud-director-ccm-crs-airgap.yaml.template
+	sed -e "s/\-__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/dependencies.txt.template > artifacts/dependencies.txt
+	sed -e "s/\-__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/bom.json.template > artifacts/bom.json
 	docker build -f ./artifacts/Dockerfile . -t cpi-crs-airgapped:$(version)
 	docker tag cpi-crs-airgapped:$(version) $(REGISTRY)/cpi-crs-airgapped:$(version)
 	docker push $(REGISTRY)/cpi-crs-airgapped:$(version)
@@ -19,9 +19,9 @@ crs-artifacts-dev:
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" artifacts/default-cloud-director-ccm-crs-airgap.yaml.template > artifacts/cloud-director-ccm-crs-airgap.yaml.template
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/dependencies.txt.template > artifacts/dependencies.txt
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/bom.json.template > artifacts/bom.json
-	docker build -f ./artifacts/Dockerfile . -t cpi-crs-airgapped:$(version).$(GITCOMMIT)
-	docker tag cpi-crs-airgapped:$(version).$(GITCOMMIT) $(REGISTRY)/cpi-crs-airgapped:$(version).$(GITCOMMIT)
-	docker push $(REGISTRY)/cpi-crs-airgapped:$(version).$(GITCOMMIT)
+	docker build -f ./artifacts/Dockerfile . -t cpi-crs-airgapped:$(version)-$(GITCOMMIT)
+	docker tag cpi-crs-airgapped:$(version)-$(GITCOMMIT) $(REGISTRY)/cpi-crs-airgapped:$(version)-$(GITCOMMIT)
+	docker push $(REGISTRY)/cpi-crs-airgapped:$(version)-$(GITCOMMIT)
 
 build-within-docker: vendor
 	mkdir -p /build/cloud-provider-for-cloud-director
@@ -30,14 +30,14 @@ build-within-docker: vendor
 ccm: $(GO_CODE)
 	docker build -f Dockerfile . -t cloud-provider-for-cloud-director:$(version)
 	docker tag cloud-provider-for-cloud-director:$(version) $(REGISTRY)/cloud-provider-for-cloud-director:$(version)
-	docker tag cloud-provider-for-cloud-director:$(version) $(REGISTRY)/cloud-provider-for-cloud-director:$(version).$(GITCOMMIT)
+	docker tag cloud-provider-for-cloud-director:$(version) $(REGISTRY)/cloud-provider-for-cloud-director:$(version)-$(GITCOMMIT)
 	docker push $(REGISTRY)/cloud-provider-for-cloud-director:$(version)
 	touch out/$@
 
 prod: ccm prod-manifest crs-artifacts-prod
 
 dev: ccm dev-manifest crs-artifacts-dev
-	docker push $(REGISTRY)/cloud-provider-for-cloud-director:$(version).$(GITCOMMIT)
+	docker push $(REGISTRY)/cloud-provider-for-cloud-director:$(version)-$(GITCOMMIT)
 
 vendor:
 	go mod edit -go=1.19
@@ -56,5 +56,5 @@ dev-manifest:
 	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" -e "s/__VERSION__/$(version)/g" manifests/cloud-director-ccm-crs.yaml.template > manifests/cloud-director-ccm-crs.yaml
 
 prod-manifest:
-	sed -e "s/\.__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" manifests/cloud-director-ccm.yaml.template > manifests/cloud-director-ccm.yaml
-	sed -e "s/\.__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" manifests/cloud-director-ccm-crs.yaml.template > manifests/cloud-director-ccm-crs.yaml
+	sed -e "s/\-__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" manifests/cloud-director-ccm.yaml.template > manifests/cloud-director-ccm.yaml
+	sed -e "s/\-__GIT_COMMIT__//g" -e "s/__VERSION__/$(version)/g" manifests/cloud-director-ccm-crs.yaml.template > manifests/cloud-director-ccm-crs.yaml

--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -1,6 +1,6 @@
 {
 	"name":"cpi-crs-airgapped",
-	"version":"__VERSION__.__GIT_COMMIT__",
+	"version":"__VERSION__-__GIT_COMMIT__",
 	"components": {
 		"manifests":[
 			{
@@ -12,7 +12,7 @@
 		"dependencies": [
 			{
 				"name":"cloud-provider-for-cloud-director",
-				"version":"__VERSION__.__GIT_COMMIT__",
+				"version":"__VERSION__-__GIT_COMMIT__",
 				"imageRepository":"__REGISTRY__"
 			}
 		]

--- a/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
+++ b/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: __REGISTRY__/cloud-provider-for-cloud-director:__VERSION__.__GIT_COMMIT__
+          image: __REGISTRY__/cloud-provider-for-cloud-director:__VERSION__-__GIT_COMMIT__
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,1 +1,1 @@
-__REGISTRY__ cloud-provider-for-cloud-director __VERSION__.__GIT_COMMIT__
+__REGISTRY__ cloud-provider-for-cloud-director __VERSION__-__GIT_COMMIT__

--- a/manifests/cloud-director-ccm-crs.yaml.template
+++ b/manifests/cloud-director-ccm-crs.yaml.template
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects-stg.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:__VERSION__.__GIT_COMMIT__
+          image: projects-stg.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:__VERSION__-__GIT_COMMIT__
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/manifests/cloud-director-ccm.yaml.template
+++ b/manifests/cloud-director-ccm.yaml.template
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects-stg.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:__VERSION__.__GIT_COMMIT__
+          image: projects-stg.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:__VERSION__-__GIT_COMMIT__
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director


### PR DESCRIPTION
* Pushes airgapped artifacts with `$version.$gitSha`, so that it matches the dev image tags in the manifests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/259)
<!-- Reviewable:end -->
