### PR TITLE
[VKCI-196] Update testing common core to add new way of retrieving kubeconfig + minor improvements to Node LCM tests

### DIFF
--- a/pkg/testingsdk/entities.go
+++ b/pkg/testingsdk/entities.go
@@ -1,0 +1,13 @@
+package testingsdk
+
+type Status struct {
+	CAPVCDStatus map[string]interface{} `json:"capvcd,omitempty"`
+}
+
+type CAPVCDEntity struct {
+	Status Status `json:"status"`
+}
+
+type FullCAPVCDEntity struct {
+	Entity CAPVCDEntity `json:"entity"`
+}

--- a/pkg/testingsdk/rde_utils.go
+++ b/pkg/testingsdk/rde_utils.go
@@ -148,8 +148,8 @@ func getDecryptedRDE(ctx context.Context, client *vcdsdk.Client, rdeID, clusterN
 }
 
 func getKubeconfigFromCapvcdStatus(capvcdStatusMap map[string]interface{}, clusterId string) (string, error) {
-	if capvcdStatusMap != nil {
-		return "", fmt.Errorf("capvcd status map is nil")
+	if capvcdStatusMap == nil {
+		return "", fmt.Errorf("capvcd status map is nil for cluster [%s]", clusterId)
 	}
 	privateStatusIf, ok := capvcdStatusMap["private"]
 	if !ok {

--- a/pkg/testingsdk/rde_utils.go
+++ b/pkg/testingsdk/rde_utils.go
@@ -4,8 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/blang/semver"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	swagger36 "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_36_0"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"io"
+	"net/http"
+	"strings"
 )
+
+const (
+	CAPVCDEntityTypeVersion120 = "1.2.0"
+	NoOpDecryptBehaviorID      = "urn:vcloud:behavior-interface:getFullEntity:cse:capvcd:1.0.0"
+)
+
+type TaskWithResult struct {
+	// NOTE: the following is the addition to the Task type in GoVCD. Represents the ResultContent within the Task object
+	ResultContent string `xml:"Result>ResultContent,omitempty"`
+}
 
 // TODO: In the future, we will need to consider how to handle different versions of RDE. Currently these functions are not resilient to RDE version changes.
 
@@ -50,11 +66,88 @@ func GetComponentMapInStatus(ctx context.Context, client *vcdsdk.Client, cluster
 }
 
 func GetKubeconfigFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterId string) (string, error) {
-	capvcdStatusMap, err := GetComponentMapInStatus(ctx, client, clusterId, vcdsdk.ComponentCAPVCD)
+	var kubeConfig string
+	var err error
+
+	clusterRde, err := getRdeById(ctx, client, clusterId)
 	if err != nil {
-		return "", fmt.Errorf("error retrieving [%s] field in status field of RDE [%s]: [%v]", vcdsdk.ComponentCAPVCD, clusterId, err)
+		return "", fmt.Errorf("error occurred while getting cluster RDE [%s]: [%v]", clusterId, err)
 	}
 
+	entityTypeSemver, _ := semver.New(getRDEVersion(clusterRde))
+	entityTypeVersion120, _ := semver.New(CAPVCDEntityTypeVersion120)
+
+	// If RDE version of the cluster is >= 1.2.0, the kubeconfig will be stored as a secure field within the RDE's CAPVCD status
+	// else, the kubeconfig can be directly obtained from the RDE
+	if entityTypeSemver.GE(*entityTypeVersion120) {
+		kubeConfig, err = getKubeconfigFromDecryptedRDE(ctx, client, clusterId, clusterRde.Name)
+	} else {
+		kubeConfig, err = getKubeconfigFromRDE110(ctx, client, clusterId)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("error occurred retrieving kubeconfig for cluster [%s(%s)] from RDE: [%v]", clusterRde.Name, clusterId, err)
+	}
+
+	if kubeConfig == "" {
+		return "", fmt.Errorf("error occurred, empty kubeconfig was retrieved from cluster RDE [%s(%s)]", clusterRde.Name, clusterId)
+	}
+	return kubeConfig, err
+}
+
+func getDecryptedRDE(ctx context.Context, client *vcdsdk.Client, rdeID, clusterName string) (*FullCAPVCDEntity, error) {
+	if client.VCDClient.Client.APIVCDMaxVersionIs(fmt.Sprintf("<%s", vcdsdk.VCloudApiVersion_37_2)) {
+		return nil, fmt.Errorf("skipping decrypt RDE for cluster [%s(%s)] as VCD API version is less than [%s]", clusterName, rdeID, vcdsdk.VCloudApiVersion_37_2)
+	}
+	if client.APIClient37_2 == nil {
+		return nil, fmt.Errorf("unable to decrypt RDE for cluster [%s(%s)] as API client for VCD API version [%s] is missing", clusterName, rdeID, vcdsdk.VCloudApiVersion_37_2)
+	}
+
+	resp, err := client.APIClient37_2.DefinedInterfaceBehaviorsApi.InvokeDefinedEntityBehavior(ctx, rdeID, NoOpDecryptBehaviorID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call decrypt behavior on RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("obtained nil response for the API call to decrypt behavior of RDE for the cluster [%s(%s)]", clusterName, rdeID)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		respBytes, err := io.ReadAll(resp.Body)
+		if err == nil {
+			return nil, fmt.Errorf("obtained error response with status code [%d] for the API call to decrypt behavior of RDE for cluster [%s(%s)]: [%s]", resp.StatusCode, clusterName, rdeID, string(respBytes))
+		}
+		return nil, fmt.Errorf("obtained unexpected response code [%d] for the API call to decrypt behavior of RDE for cluster [%s(%s)]", resp.StatusCode, clusterName, rdeID)
+	}
+
+	decryptEntityTaskUrl := resp.Header.Get("Location")
+	if decryptEntityTaskUrl == "" {
+		return nil, fmt.Errorf("unexpected response for decrypt behavior of RDE for cluster [%s(%s)] - task URL is empty", clusterName, rdeID)
+	}
+	task := govcd.NewTask(&client.VCDClient.Client)
+	task.Task.HREF = resp.Header.Get("Location")
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("task for enitity decryption failed for RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+
+	// The following request to get the task needs to be explicitly made because GoVCD type for Task doesn't parse the Result field in the response.
+	taskResult := &TaskWithResult{}
+	_, err = client.VCDClient.Client.ExecuteRequest(decryptEntityTaskUrl, http.MethodGet, "", "error getting task: %s", nil, taskResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read task response after decrypting RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+	if taskResult.ResultContent == "" {
+		return nil, fmt.Errorf("unexpected error - decrypted task is empty for RDE for cluster [%s(%s)]", clusterName, rdeID)
+	}
+
+	// parse the ResultContent in the task into capvcdFullDefinedEntity type structure
+	capvcdFullRDE := &FullCAPVCDEntity{}
+	if err := json.Unmarshal([]byte(taskResult.ResultContent), capvcdFullRDE); err != nil {
+		return nil, fmt.Errorf("failed to parse decrypted entity into CAPVCD struct for RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+	return capvcdFullRDE, nil
+}
+
+func getKubeconfigFromCapvcdStatus(capvcdStatusMap map[string]interface{}, clusterId string) (string, error) {
 	privateStatusIf, ok := capvcdStatusMap["private"]
 	if !ok {
 		return "", fmt.Errorf("private field not found in status->capvcd of RDE [%s]", clusterId)
@@ -70,6 +163,30 @@ func GetKubeconfigFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterI
 		return "", fmt.Errorf("kubeConfig field not found in status->capvcd->private of RDE [%s]", clusterId)
 	}
 	return kubeConfig.(string), nil
+}
+
+func getKubeconfigFromRDE110(ctx context.Context, client *vcdsdk.Client, clusterId string) (string, error) {
+	capvcdStatusMap, err := GetComponentMapInStatus(ctx, client, clusterId, vcdsdk.ComponentCAPVCD)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving [%s] field in status field of RDE [%s]: [%v]", vcdsdk.ComponentCAPVCD, clusterId, err)
+	}
+	return getKubeconfigFromCapvcdStatus(capvcdStatusMap, clusterId)
+}
+
+func getKubeconfigFromDecryptedRDE(ctx context.Context, client *vcdsdk.Client, clusterId, clusterName string) (string, error) {
+	fullCapvcdRde, err := getDecryptedRDE(ctx, client, clusterId, clusterName)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving kubeconfig for cluster [%s(%s)] from decrypted RDE: [%v]", clusterName, clusterId, err)
+	}
+
+	capvcdStatusMap := fullCapvcdRde.Entity.Status.CAPVCDStatus
+	return getKubeconfigFromCapvcdStatus(capvcdStatusMap, clusterId)
+}
+
+func getRDEVersion(rde *swagger36.DefinedEntity) string {
+	entiyTypeSplitArr := strings.Split(rde.EntityType, ":")
+	// last item of the array will be the version string
+	return entiyTypeSplitArr[len(entiyTypeSplitArr)-1]
 }
 
 func getVcdResourceSetComponentMapFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterId, componentName string) (interface{}, error) {

--- a/pkg/testingsdk/rde_utils.go
+++ b/pkg/testingsdk/rde_utils.go
@@ -148,6 +148,9 @@ func getDecryptedRDE(ctx context.Context, client *vcdsdk.Client, rdeID, clusterN
 }
 
 func getKubeconfigFromCapvcdStatus(capvcdStatusMap map[string]interface{}, clusterId string) (string, error) {
+	if capvcdStatusMap != nil {
+		return "", fmt.Errorf("capvcd status map is nil")
+	}
 	privateStatusIf, ok := capvcdStatusMap["private"]
 	if !ok {
 		return "", fmt.Errorf("private field not found in status->capvcd of RDE [%s]", clusterId)


### PR DESCRIPTION
* Update kubeconfig retrieval such that it can support both RDE entity type 1.1.0, and 1.2.0
* Improvements to Node LCM tests to skip rather than outright fail when cluster does not have 2 or more worker nodes
* Tested against 2 clusters:
  * RDE 1.1.0 – 1x CP, 2x Worker -≥ LCM/LB tests passed
  * RDE 1.2.0 – 1x CP, 1x Worker -> LCM tests skipped due to 1 worker, LB tests passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/262)
<!-- Reviewable:end -->
