### PR TITLE
[VKCI-196] Cherrypick – Update testing common core to add new way of retrieving kubeconfig

### DIFF
--- a/pkg/testingsdk/entities.go
+++ b/pkg/testingsdk/entities.go
@@ -1,0 +1,13 @@
+package testingsdk
+
+type Status struct {
+	CAPVCDStatus map[string]interface{} `json:"capvcd,omitempty"`
+}
+
+type CAPVCDEntity struct {
+	Status Status `json:"status"`
+}
+
+type FullCAPVCDEntity struct {
+	Entity CAPVCDEntity `json:"entity"`
+}

--- a/pkg/testingsdk/rde_utils.go
+++ b/pkg/testingsdk/rde_utils.go
@@ -4,8 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/blang/semver"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	swagger36 "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_36_0"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"io"
+	"net/http"
+	"strings"
 )
+
+const (
+	CAPVCDEntityTypeVersion120 = "1.2.0"
+	NoOpDecryptBehaviorID      = "urn:vcloud:behavior-interface:getFullEntity:cse:capvcd:1.0.0"
+)
+
+type TaskWithResult struct {
+	// NOTE: the following is the addition to the Task type in GoVCD. Represents the ResultContent within the Task object
+	ResultContent string `xml:"Result>ResultContent,omitempty"`
+}
 
 // TODO: In the future, we will need to consider how to handle different versions of RDE. Currently these functions are not resilient to RDE version changes.
 
@@ -50,11 +66,101 @@ func GetComponentMapInStatus(ctx context.Context, client *vcdsdk.Client, cluster
 }
 
 func GetKubeconfigFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterId string) (string, error) {
-	capvcdStatusMap, err := GetComponentMapInStatus(ctx, client, clusterId, vcdsdk.ComponentCAPVCD)
+	var kubeConfig string
+	var err error
+
+	clusterRde, err := getRdeById(ctx, client, clusterId)
 	if err != nil {
-		return "", fmt.Errorf("error retrieving [%s] field in status field of RDE [%s]: [%v]", vcdsdk.ComponentCAPVCD, clusterId, err)
+		return "", fmt.Errorf("error occurred while getting cluster RDE [%s]: [%v]", clusterId, err)
 	}
 
+	entityTypeSemver, err := semver.New(getRDEVersion(clusterRde))
+	if err != nil {
+		return "", fmt.Errorf("error creating semver for retrieved RDE version from cluster [%s(%s)]: [%v]", clusterRde.Name, clusterId, err)
+	}
+	entityTypeVersion120, err := semver.New(CAPVCDEntityTypeVersion120)
+	if err != nil {
+		return "", fmt.Errorf("error creating semver from [%s] for comparison with RDE version: [%v]", CAPVCDEntityTypeVersion120, err)
+	}
+
+	// If RDE version of the cluster is >= 1.2.0, the kubeconfig will be stored as a secure field within the RDE's CAPVCD status
+	// else, the kubeconfig can be directly obtained from the RDE
+
+	// VCD/API version checks are not needed here because it is not possible to register RDE 1.2.0 for VCD builds 10.4.1 and below.
+	// So all RDE versions are expected to be 1.1.0 from VCD 10.4.1 and below. It should not be possible to have a RDE 1.2.0 + VCD 10.3.x/10.4.1.
+	// RDE 1.2.0 is only supported for VCD 10.4.2+, as UI will perform the API checks and register the appropriate schema.
+	if entityTypeSemver.GE(*entityTypeVersion120) {
+		kubeConfig, err = getKubeconfigFromDecryptedRDE(ctx, client, clusterId, clusterRde.Name)
+	} else {
+		kubeConfig, err = getKubeconfigFromRDE110(ctx, client, clusterId)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("error occurred retrieving kubeconfig for cluster [%s(%s)] from RDE: [%v]", clusterRde.Name, clusterId, err)
+	}
+
+	if kubeConfig == "" {
+		return "", fmt.Errorf("error occurred, empty kubeconfig was retrieved from cluster RDE [%s(%s)]", clusterRde.Name, clusterId)
+	}
+	return kubeConfig, err
+}
+
+func getDecryptedRDE(ctx context.Context, client *vcdsdk.Client, rdeID, clusterName string) (*FullCAPVCDEntity, error) {
+	if client.VCDClient.Client.APIVCDMaxVersionIs(fmt.Sprintf("<%s", vcdsdk.VCloudApiVersion_37_2)) {
+		return nil, fmt.Errorf("skipping decrypt RDE for cluster [%s(%s)] as VCD API version is less than [%s]", clusterName, rdeID, vcdsdk.VCloudApiVersion_37_2)
+	}
+	if client.APIClient37_2 == nil {
+		return nil, fmt.Errorf("unable to decrypt RDE for cluster [%s(%s)] as API client for VCD API version [%s] is missing", clusterName, rdeID, vcdsdk.VCloudApiVersion_37_2)
+	}
+
+	resp, err := client.APIClient37_2.DefinedInterfaceBehaviorsApi.InvokeDefinedEntityBehavior(ctx, rdeID, NoOpDecryptBehaviorID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call decrypt behavior on RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("obtained nil response for the API call to decrypt behavior of RDE for the cluster [%s(%s)]", clusterName, rdeID)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		respBytes, err := io.ReadAll(resp.Body)
+		if err == nil {
+			return nil, fmt.Errorf("obtained error response with status code [%d] for the API call to decrypt behavior of RDE for cluster [%s(%s)]: [%s]", resp.StatusCode, clusterName, rdeID, string(respBytes))
+		}
+		return nil, fmt.Errorf("obtained unexpected response code [%d] for the API call to decrypt behavior of RDE for cluster [%s(%s)]", resp.StatusCode, clusterName, rdeID)
+	}
+
+	decryptEntityTaskUrl := resp.Header.Get("Location")
+	if decryptEntityTaskUrl == "" {
+		return nil, fmt.Errorf("unexpected response for decrypt behavior of RDE for cluster [%s(%s)] - task URL is empty", clusterName, rdeID)
+	}
+	task := govcd.NewTask(&client.VCDClient.Client)
+	task.Task.HREF = resp.Header.Get("Location")
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("task for enitity decryption failed for RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+
+	// The following request to get the task needs to be explicitly made because GoVCD type for Task doesn't parse the Result field in the response.
+	taskResult := &TaskWithResult{}
+	_, err = client.VCDClient.Client.ExecuteRequest(decryptEntityTaskUrl, http.MethodGet, "", "error getting task: %s", nil, taskResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read task response after decrypting RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+	if taskResult.ResultContent == "" {
+		return nil, fmt.Errorf("unexpected error - decrypted task is empty for RDE for cluster [%s(%s)]", clusterName, rdeID)
+	}
+
+	// parse the ResultContent in the task into capvcdFullDefinedEntity type structure
+	capvcdFullRDE := &FullCAPVCDEntity{}
+	if err := json.Unmarshal([]byte(taskResult.ResultContent), capvcdFullRDE); err != nil {
+		return nil, fmt.Errorf("failed to parse decrypted entity into CAPVCD struct for RDE for cluster [%s(%s)]: [%v]", clusterName, rdeID, err)
+	}
+	return capvcdFullRDE, nil
+}
+
+func getKubeconfigFromCapvcdStatus(capvcdStatusMap map[string]interface{}, clusterId string) (string, error) {
+	if capvcdStatusMap == nil {
+		return "", fmt.Errorf("capvcd status map is nil for cluster [%s]", clusterId)
+	}
 	privateStatusIf, ok := capvcdStatusMap["private"]
 	if !ok {
 		return "", fmt.Errorf("private field not found in status->capvcd of RDE [%s]", clusterId)
@@ -70,6 +176,30 @@ func GetKubeconfigFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterI
 		return "", fmt.Errorf("kubeConfig field not found in status->capvcd->private of RDE [%s]", clusterId)
 	}
 	return kubeConfig.(string), nil
+}
+
+func getKubeconfigFromRDE110(ctx context.Context, client *vcdsdk.Client, clusterId string) (string, error) {
+	capvcdStatusMap, err := GetComponentMapInStatus(ctx, client, clusterId, vcdsdk.ComponentCAPVCD)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving [%s] field in status field of RDE [%s]: [%v]", vcdsdk.ComponentCAPVCD, clusterId, err)
+	}
+	return getKubeconfigFromCapvcdStatus(capvcdStatusMap, clusterId)
+}
+
+func getKubeconfigFromDecryptedRDE(ctx context.Context, client *vcdsdk.Client, clusterId, clusterName string) (string, error) {
+	fullCapvcdRde, err := getDecryptedRDE(ctx, client, clusterId, clusterName)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving kubeconfig for cluster [%s(%s)] from decrypted RDE: [%v]", clusterName, clusterId, err)
+	}
+
+	capvcdStatusMap := fullCapvcdRde.Entity.Status.CAPVCDStatus
+	return getKubeconfigFromCapvcdStatus(capvcdStatusMap, clusterId)
+}
+
+func getRDEVersion(rde *swagger36.DefinedEntity) string {
+	entiyTypeSplitArr := strings.Split(rde.EntityType, ":")
+	// last item of the array will be the version string
+	return entiyTypeSplitArr[len(entiyTypeSplitArr)-1]
 }
 
 func getVcdResourceSetComponentMapFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterId, componentName string) (interface{}, error) {


### PR DESCRIPTION
…beconfig + minor improvements to Node LCM tests (#262)

* Update kubeconfig retrieval so it supports both RDE 1.1.0, 1.2.0

Signed-off-by: lzichong <lzichong@vmware.com>

* Update Node LCM tests so that it does not outright fail if cluster does not have 2+ worker nodes

Signed-off-by: lzichong <lzichong@vmware.com>

* Add a nil check for capvcd status map in the event that it's missing from rde.capvcd.status

Signed-off-by: lzichong <lzichong@vmware.com>

* Correct condition check + cluster id logging

Signed-off-by: lzichong <lzichong@vmware.com>

* Address Yan CR: Add error check for semver versions, add comment for VCD versions

Signed-off-by: lzichong <lzichong@vmware.com>

---------

Signed-off-by: lzichong <lzichong@vmware.com>
(cherry picked from commit 3890a129df0c6c2e15eadfd5e03f788c1a0fd5a2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/263)
<!-- Reviewable:end -->
