### PR TITLE
[VKCI-203] Fix inconsistent 503 from GET reqs by waiting for Deployment to be ready

### DIFF
--- a/tests/e2e/loadbalancer_test.go
+++ b/tests/e2e/loadbalancer_test.go
@@ -84,6 +84,9 @@ var _ = Describe("Ensure Loadbalancer", func() {
 		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
 		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
 		Expect(err).NotTo(HaveOccurred())
+		err = tc.WaitForDeploymentReady(ctx, ns.Name, testDeploymentName)
+		Expect(err).NotTo(HaveOccurred())
+
 		svc, err = tc.CreateLoadBalancerService(ctx, ns.Name, testServiceName, nil, labels, httpServicePort, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc).NotTo(BeNil())
@@ -226,6 +229,8 @@ var _ = Describe("Ensure load balancer with user specified LB IP", func() {
 
 		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
 		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
+		Expect(err).NotTo(HaveOccurred())
+		err = tc.WaitForDeploymentReady(ctx, ns.Name, testDeploymentName)
 		Expect(err).NotTo(HaveOccurred())
 
 		svc, err = tc.CreateLoadBalancerService(ctx, ns.Name, testServiceName, nil, labels, httpServicePort, explicitIP)


### PR DESCRIPTION
* By waiting for the Deployment to come up, we will have ensured the server is up and running, and only then we should make the GET requests.
* Added `WaitForDeployment()` as part of the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/271)
<!-- Reviewable:end -->
