### PR TITLE
[VKCI-212] Remove fields from CPI deployment as a result of PodSecurityPolicy deprecation and removal from Kubernetes

### DIFF
--- a/manifests/cloud-director-ccm-crs.yaml
+++ b/manifests/cloud-director-ccm-crs.yaml
@@ -150,8 +150,6 @@ spec:
       serviceAccountName: cloud-controller-manager
       securityContext:
         runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
           image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:1.4.0

--- a/manifests/cloud-director-ccm-crs.yaml.template
+++ b/manifests/cloud-director-ccm-crs.yaml.template
@@ -150,8 +150,6 @@ spec:
       serviceAccountName: cloud-controller-manager
       securityContext:
         runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
           image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:__VERSION__

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -150,8 +150,6 @@ spec:
       serviceAccountName: cloud-controller-manager
       securityContext:
         runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
           image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:1.4.0

--- a/manifests/cloud-director-ccm.yaml.template
+++ b/manifests/cloud-director-ccm.yaml.template
@@ -150,8 +150,6 @@ spec:
       serviceAccountName: cloud-controller-manager
       securityContext:
         runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
           image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:__VERSION__


### PR DESCRIPTION
- changes done as per https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/#eliminate-non-standard-options
- remove the following fields from deployment spec
  - runAsGroup
  - fsGroup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/280)
<!-- Reviewable:end -->
