### PR TITLE
[VKCI-214] Add support for airgap and staging images, add ContainerStatus check to DeploymentReady check

### DIFF
--- a/pkg/testingsdk/k8sclient.go
+++ b/pkg/testingsdk/k8sclient.go
@@ -79,7 +79,14 @@ func waitForDeploymentReady(ctx context.Context, k8sClient *kubernetes.Clientset
 		ready := 0
 		for _, pod := range (*podList).Items {
 			if pod.Status.Phase == apiv1.PodRunning {
-				ready++
+				// Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+				// Pod running state can mean: at least one container is still running, or is in the process of starting or restarting.
+				// It's possible that the container is just starting up and not fully ready, so we should also check if ContainerStatus is ready.
+				for _, container := range pod.Status.ContainerStatuses {
+					if container.Ready {
+						ready++
+					}
+				}
 			}
 		}
 		if ready < podCount {

--- a/pkg/testingsdk/k8sclient.go
+++ b/pkg/testingsdk/k8sclient.go
@@ -75,12 +75,12 @@ func waitForDeploymentReady(ctx context.Context, k8sClient *kubernetes.Clientset
 			return false, fmt.Errorf("unexpected error occurred while getting deployment [%s]", deployName)
 		}
 		podCount := len(podList.Items)
-		containersCount := 0
+		containerCount := 0
 		podsReady := 0
 		containersReady := 0
 		for _, pod := range (*podList).Items {
 			// Add the total amount of containers per pod
-			containersCount += len(pod.Spec.Containers)
+			containerCount += len(pod.Spec.Containers)
 			if pod.Status.Phase == apiv1.PodRunning {
 				// Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
 				// Pod running state can mean: at least one container is still running, or is in the process of starting or restarting.
@@ -93,8 +93,8 @@ func waitForDeploymentReady(ctx context.Context, k8sClient *kubernetes.Clientset
 				}
 			}
 		}
-		if podsReady < podCount || containersReady < containersCount {
-			fmt.Printf("running pods: %v < %v; ready containers: %v < %v\n", podsReady, podCount, containersReady, containersCount)
+		if podsReady < podCount || containersReady < containerCount {
+			fmt.Printf("running pods: %v < %v; ready containers: %v < %v\n", podsReady, podCount, containersReady, containerCount)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/testingsdk/k8sclient.go
+++ b/pkg/testingsdk/k8sclient.go
@@ -93,6 +93,13 @@ func waitForDeploymentReady(ctx context.Context, k8sClient *kubernetes.Clientset
 				}
 			}
 		}
+		// It is possible to have a race condition where Pods are not up yet and in testing code it can think that the Deployment is ready
+		// Because there are no Pods up yet, though Deployment has been applied.
+		if podCount == 0 || containerCount == 0 {
+			fmt.Printf("no containers or pods are ready yet")
+			return false, nil
+		}
+
 		if podsReady < podCount || containersReady < containerCount {
 			fmt.Printf("running pods: %v < %v; ready containers: %v < %v\n", podsReady, podCount, containersReady, containerCount)
 			return false, nil

--- a/pkg/testingsdk/k8sclient.go
+++ b/pkg/testingsdk/k8sclient.go
@@ -81,21 +81,26 @@ func waitForDeploymentReady(ctx context.Context, k8sClient *kubernetes.Clientset
 		for _, pod := range (*podList).Items {
 			// Add the total amount of containers per pod
 			containerCount += len(pod.Spec.Containers)
+			containersReadyFromCurrentPod := 0
 			if pod.Status.Phase == apiv1.PodRunning {
 				// Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
 				// Pod running state can mean: at least one container is still running, or is in the process of starting or restarting.
 				// It's possible that the container is just starting up and not fully ready, so we should also check if ContainerStatus is ready.
 				for _, container := range pod.Status.ContainerStatuses {
 					if container.Ready {
-						podsReady++
-						containersReady++
+						containersReadyFromCurrentPod++
 					}
+				}
+
+				if containersReadyFromCurrentPod == len(pod.Spec.Containers) {
+					podsReady++
+					containersReady += containersReadyFromCurrentPod
 				}
 			}
 		}
 		// It is possible to have a race condition where Pods are not up yet and in testing code it can think that the Deployment is ready
 		// Because there are no Pods up yet, though Deployment has been applied.
-		if podCount == 0 || containerCount == 0 {
+		if podCount == 0 {
 			fmt.Printf("no containers or pods are ready yet")
 			return false, nil
 		}

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"flag"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -16,6 +17,13 @@ var (
 	ovdcName  string
 	username  string
 	token     string
+
+	ContainerImage string
+)
+
+const (
+	airgappedImage = "core.harbor.10.89.98.101.nip.io/airgapped/agnhost:2.36"
+	stagingImage   = "projects-stg.registry.vmware.com/vmware-cloud-director/agnhost:2.36"
 )
 
 func init() {
@@ -38,6 +46,14 @@ var _ = BeforeSuite(func() {
 	Expect(username).NotTo(BeEmpty(), "Please make sure --username is set correctly.")
 	Expect(token).NotTo(BeEmpty(), "Please make sure --token is set correctly.")
 	Expect(clusterId).NotTo(BeEmpty(), "Please make sure --clusterId is set correctly.")
+
+	// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
+	useAirgap := os.Getenv("AIRGAP")
+	if useAirgap != "" {
+		ContainerImage = airgappedImage
+	} else {
+		ContainerImage = stagingImage
+	}
 })
 
 func TestE2e(t *testing.T) {

--- a/tests/e2e/loadbalancer_test.go
+++ b/tests/e2e/loadbalancer_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Ensure Loadbalancer", func() {
 	Expect(&tc.Cs).NotTo(BeNil())
 
 	labels := map[string]string{
-		"app": testServiceName,
+		"app": testDeploymentName,
 	}
 
 	httpServicePort := []v1.ServicePort{{
@@ -183,7 +183,7 @@ var _ = Describe("Ensure load balancer with user specified LB IP", func() {
 	Expect(&tc.Cs).NotTo(BeNil())
 
 	labels := map[string]string{
-		"app": testServiceName,
+		"app": testDeploymentName,
 	}
 
 	httpServicePort := []v1.ServicePort{{

--- a/tests/e2e/loadbalancer_test.go
+++ b/tests/e2e/loadbalancer_test.go
@@ -11,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"net/http"
-	"os"
 )
 
 const (
@@ -21,9 +20,6 @@ const (
 	httpPort           = 80
 
 	ccmConfigMapName = "vcloud-ccm-configmap"
-
-	airgappedImage = "core.harbor.10.89.98.101.nip.io/airgapped/agnhost:2.36"
-	stagingImage   = "projects-stg.registry.vmware.com/vmware-cloud-director/agnhost:2.36"
 )
 
 var testHttpName = "http"
@@ -84,16 +80,10 @@ var _ = Describe("Ensure Loadbalancer", func() {
 		By("creating a http load balancer service")
 		ns, err = tc.CreateNameSpace(ctx, testBaseName)
 		Expect(err).NotTo(HaveOccurred())
-		// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
-		useAirgap := os.Getenv("AIRGAP")
-		if useAirgap != "" {
-			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, airgappedImage, labels)
-			Expect(err).NotTo(HaveOccurred())
-		} else {
-			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, stagingImage, labels)
-			Expect(err).NotTo(HaveOccurred())
-		}
+
 		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
+		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, ContainerImage, labels)
+		Expect(err).NotTo(HaveOccurred())
 		err = tc.WaitForDeploymentReady(ctx, ns.Name, testDeploymentName)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -236,16 +226,10 @@ var _ = Describe("Ensure load balancer with user specified LB IP", func() {
 		By("creating a http load balancer service")
 		ns, err = tc.CreateNameSpace(ctx, testBaseName)
 		Expect(err).NotTo(HaveOccurred())
-		// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
-		useAirgap := os.Getenv("AIRGAP")
-		if useAirgap != "" {
-			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, airgappedImage, labels)
-			Expect(err).NotTo(HaveOccurred())
-		} else {
-			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, stagingImage, labels)
-			Expect(err).NotTo(HaveOccurred())
-		}
+
 		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
+		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, ContainerImage, labels)
+		Expect(err).NotTo(HaveOccurred())
 		err = tc.WaitForDeploymentReady(ctx, ns.Name, testDeploymentName)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/e2e/loadbalancer_test.go
+++ b/tests/e2e/loadbalancer_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"net/http"
+	"os"
 )
 
 const (
@@ -20,6 +21,9 @@ const (
 	httpPort           = 80
 
 	ccmConfigMapName = "vcloud-ccm-configmap"
+
+	airgappedImage = "core.harbor.10.89.98.101.nip.io/airgapped/agnhost:2.36"
+	stagingImage   = "projects-stg.registry.vmware.com/vmware-cloud-director/agnhost:2.36"
 )
 
 var testHttpName = "http"
@@ -80,10 +84,16 @@ var _ = Describe("Ensure Loadbalancer", func() {
 		By("creating a http load balancer service")
 		ns, err = tc.CreateNameSpace(ctx, testBaseName)
 		Expect(err).NotTo(HaveOccurred())
-
+		// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
+		useAirgap := os.Getenv("AIRGAP")
+		if useAirgap != "" {
+			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, airgappedImage, labels)
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, stagingImage, labels)
+			Expect(err).NotTo(HaveOccurred())
+		}
 		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
-		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
-		Expect(err).NotTo(HaveOccurred())
 		err = tc.WaitForDeploymentReady(ctx, ns.Name, testDeploymentName)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -226,10 +236,16 @@ var _ = Describe("Ensure load balancer with user specified LB IP", func() {
 		By("creating a http load balancer service")
 		ns, err = tc.CreateNameSpace(ctx, testBaseName)
 		Expect(err).NotTo(HaveOccurred())
-
+		// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
+		useAirgap := os.Getenv("AIRGAP")
+		if useAirgap != "" {
+			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, airgappedImage, labels)
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, stagingImage, labels)
+			Expect(err).NotTo(HaveOccurred())
+		}
 		// We will have a sample deployment so the server will return some sort of data back to us using an official e2e test image
-		_, err = utils.CreateDeployment(ctx, tc, testDeploymentName, ns.Name, labels)
-		Expect(err).NotTo(HaveOccurred())
 		err = tc.WaitForDeploymentReady(ctx, ns.Name, testDeploymentName)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -10,16 +10,16 @@ import (
 const (
 	clusterUrnPrefix = "urn:vcloud:entity:vmware:"
 
-	containerName  = "test-app"
-	containerImage = "k8s.gcr.io/e2e-test-images/agnhost:2.36"
+	containerName = "test-app"
 )
 
-/**
+/*
+*
 CreateDeployment creates a Deployment object with agnhost image which is a E2E testing image.
 `netexec` is a command used to run HTTP server on agnhost at certain port specified with --http-port flag.
 Reference: https://github.com/kubernetes/kubernetes/issues/90211
 */
-func CreateDeployment(ctx context.Context, tc *testingsdk.TestClient, name, namespace string, labels map[string]string) (*appsv1.Deployment, error) {
+func CreateDeployment(ctx context.Context, tc *testingsdk.TestClient, name, namespace, containerImage string, labels map[string]string) (*appsv1.Deployment, error) {
 	deploymentParams := &testingsdk.DeployParams{
 		Name:   name,
 		Labels: labels,


### PR DESCRIPTION
* Uses environment variables to indicate whether it's an airgap run or not, and use correct images for Deployment creation
* Add additional check for Container's status on top of PodRunning state before marking Deployment as ready

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/283)
<!-- Reviewable:end -->
