### PR TITLE
[VKCI-221] Create test for fetching kubeconfig, and saving it to specified path

### DIFF
--- a/tests/kubeconfig_test/kubeconfig_retrieval_test.go
+++ b/tests/kubeconfig_test/kubeconfig_retrieval_test.go
@@ -1,0 +1,47 @@
+package kubeconfig_test
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	"github.com/vmware/cloud-provider-for-cloud-director/tests/kubeconfig_test/utils"
+	"os"
+)
+
+var _ = Describe("Fetch Kubeconfig from RDE", func() {
+	var (
+		err        error
+		vcdClient  *vcdsdk.Client
+		kubeConfig string
+	)
+
+	vcdClient, err = vcdsdk.NewVCDClientFromSecrets(host, org, ovdcName, userOrg, username, "", token, true, false)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(vcdClient).NotTo(BeNil())
+
+	It("should be able to fetch kubeconfig from RDE ID", func() {
+		kubeConfig, err = testingsdk.GetKubeconfigFromRDEId(context.TODO(), vcdClient, clusterId)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kubeConfig).NotTo(BeEmpty())
+
+	})
+
+	It("should be able to write a kubeconfig file to output path", func() {
+		// Write kubeconfig directly to a file for access.
+		kubeconfigFile := []byte(kubeConfig)
+		Expect(kubeconfigFile).NotTo(BeEmpty())
+
+		// Trim trailing slashes if there are any passed in, and use that path to create a kubeconfig.
+		exportPath := utils.TrimTrailingSlash(kubeconfigExportPath)
+		outputPath := fmt.Sprintf("%s/%s.conf", exportPath, "cluster_kubeconfig")
+		err = os.WriteFile(outputPath, kubeconfigFile, 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check if the kubeconfig file exists.
+		_, err = os.Stat(outputPath)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error occurred: [%v]", err))
+	})
+})

--- a/tests/kubeconfig_test/kubeconfig_suite_test.go
+++ b/tests/kubeconfig_test/kubeconfig_suite_test.go
@@ -1,0 +1,52 @@
+package kubeconfig_test
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	clusterId string
+	host      string
+	org       string
+	userOrg   string
+	ovdcName  string
+	username  string
+	token     string
+
+	kubeconfigExportPath string
+)
+
+func init() {
+	//Inputs needed: VCD site, org, ovdc, username, refreshToken, clusterId
+	flag.StringVar(&host, "host", "", "VCD host site to generate client")
+	flag.StringVar(&org, "org", "", "Cluster Org to generate client")
+	flag.StringVar(&userOrg, "userOrg", "", "User Org to generate client")
+	flag.StringVar(&ovdcName, "ovdcName", "", "Ovdc Name to generate client")
+	flag.StringVar(&username, "username", "", "Username for login to generate client")
+	flag.StringVar(&token, "token", "", "Refresh token of user to generate client")
+	flag.StringVar(&clusterId, "clusterId", "", "Cluster ID to fetch cluster RDE")
+
+	// Use directory "." as the default directory in case kubeconfigExportPath is forgotten to be passed, otherwise use the passed in path.
+	flag.StringVar(&kubeconfigExportPath, "kubeconfigExportPath", ".", "Absolute path to save/write the retrieved kubeconfig file to")
+}
+
+var _ = BeforeSuite(func() {
+	// We should validate that all credentials are present for generating a TestClient
+	Expect(host).NotTo(BeEmpty(), "Please make sure --host is set correctly.")
+	Expect(org).NotTo(BeEmpty(), "Please make sure --org is set correctly.")
+	Expect(userOrg).NotTo(BeEmpty(), "Please make sure --userOrg is set correctly.")
+	Expect(ovdcName).NotTo(BeEmpty(), "Please make sure --ovdcName is set correctly.")
+	Expect(username).NotTo(BeEmpty(), "Please make sure --username is set correctly.")
+	Expect(token).NotTo(BeEmpty(), "Please make sure --token is set correctly.")
+	Expect(clusterId).NotTo(BeEmpty(), "Please make sure --clusterId is set correctly.")
+	Expect(kubeconfigExportPath).NotTo(BeEmpty(), "Please make sure --kubeconfigExportPath is set for saving the kubeconfig file")
+})
+
+func TestKubeconfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubeconfig Suite")
+}

--- a/tests/kubeconfig_test/utils/utils.go
+++ b/tests/kubeconfig_test/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import "strings"
 
+// TrimTrailingSlash is used to trimming the final slash of directory/path's passed in.
+// Such that it can support paths like /tmp/ and /tmp as the inputs, and create a file output as /tmp/file.txt
 func TrimTrailingSlash(path string) string {
 	if strings.HasSuffix(path, "/") {
 		return path[:len(path)-1]

--- a/tests/kubeconfig_test/utils/utils.go
+++ b/tests/kubeconfig_test/utils/utils.go
@@ -1,0 +1,10 @@
+package utils
+
+import "strings"
+
+func TrimTrailingSlash(path string) string {
+	if strings.HasSuffix(path, "/") {
+		return path[:len(path)-1]
+	}
+	return path
+}


### PR DESCRIPTION
* Uses vcdClient to fetch kubeconfig from RDE
* Saves it to a directory for future use such as Jenkins agents

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/287)
<!-- Reviewable:end -->
