### PR TITLE
[VCDA-6520] update client vdc only if tenant org is not empty

### DIFF
--- a/pkg/vcdsdk/client.go
+++ b/pkg/vcdsdk/client.go
@@ -93,18 +93,20 @@ func (client *Client) RefreshBearerToken() error {
 	}
 
 	// reset legacy client
-	org, err := client.VCDClient.GetOrgByNameOrId(client.ClusterOrgName)
-	if err != nil {
-		return fmt.Errorf("unable to get vcd organization [%s]: [%v]",
-			client.ClusterOrgName, err)
+	// Update client VDC if cluster org is provided
+	if client.ClusterOrgName != "" {
+		org, err := client.VCDClient.GetOrgByNameOrId(client.ClusterOrgName)
+		if err != nil {
+			return fmt.Errorf("unable to get vcd organization [%s]: [%v]",
+				client.ClusterOrgName, err)
+		}
+		vdc, err := org.GetVDCByName(client.ClusterOVDCName, true)
+		if err != nil {
+			return fmt.Errorf("unable to get VDC from org [%s], VDC [%s]: [%v]",
+				client.ClusterOrgName, client.VCDAuthConfig.VDC, err)
+		}
+		client.VDC = vdc
 	}
-
-	vdc, err := org.GetVDCByName(client.ClusterOVDCName, true)
-	if err != nil {
-		return fmt.Errorf("unable to get VDC from org [%s], VDC [%s]: [%v]",
-			client.ClusterOrgName, client.VCDAuthConfig.VDC, err)
-	}
-	client.VDC = vdc
 
 	// reset swagger client
 	swaggerConfig := swaggerClient.NewConfiguration()


### PR DESCRIPTION
Fix: Update VCD client with tenant vdc only if tenant org is provided. 
Description: RefreshBearerToken() throws error on empty org information when vcd client is updated.
Blocks: This is a blocker for https://jira.eng.vmware.com/browse/VCDA-6273 (VCD client for VCDKEConfig ACL updates need to be refreshed frequently)

@lzichong @arunmk 