### PR TITLE
Fix CPI test for air-gapped env

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 const (
-	airgappedImage = "core.harbor.10.89.98.101.nip.io/airgapped/agnhost:2.36"
+	airgappedImage = "harbor.10.221.134.246.nip.io/airgapped/agnhost:2.36"
 	stagingImage   = "projects-stg.registry.vmware.com/vmware-cloud-director/agnhost:2.36"
 )
 


### PR DESCRIPTION
During merge of cse-2-24-next branch into main, the private registry info in e2e test was overwritten to an old private registry. This PR reverts the change related to private registry in e2e tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/310)
<!-- Reviewable:end -->
