### PR TITLE
VKCI-244: remove all omitempty from swagger

### DIFF
--- a/pkg/vcdswaggerclient_36_0/model_edge_load_balancer_pool_modified.go
+++ b/pkg/vcdswaggerclient_36_0/model_edge_load_balancer_pool_modified.go
@@ -42,7 +42,7 @@ type EdgeLoadBalancerPool struct {
 	// The destination server port used by the traffic sent to the member.
 	DefaultPort int32 `json:"defaultPort,omitempty"`
 	// Maximum time (in minutes) to gracefully disable a member. Virtual service waits for the specified time before terminating the existing connections to the members that are disabled. <code>Special values: 0 represents 'Immediate', -1 represents 'Infinite'.</code>
-	GracefulTimeoutPeriod int32 `json:"gracefulTimeoutPeriod,omitempty"`
+	GracefulTimeoutPeriod int32 `json:"gracefulTimeoutPeriod"`
 	// The algorithm for choosing a member within the pool's list of available members for each new connection. Default value is \"LEAST_CONNECTIONS\". Supported algorithms are: <ul> <li>LEAST_CONNECTIONS <li>ROUND_ROBIN <li>CONSISTENT_HASH <li>FASTEST_RESPONSE <li>LEAST_LOAD <li>FEWEST_SERVERS <li>RANDOM <li>FEWEST_TASKS <li>CORE_AFFINITY </ul> <em>CONSISTENT_HASH</em> uses Source IP Address hash. Using <em>FASTEST_RESPONSE</em>, <em>LEAST_LOAD</em>, <em>FEWEST_SERVERS</em>, <em>RANDOM</em>, <em>FEWEST_TASKS</em>, <em>CORE_AFFINITY</em> algorithms may require additional licensing.
 	Algorithm string `json:"algorithm,omitempty"`
 	// Member server's health can be monitored by using one or more health monitors. Active monitors generate synthetic traffic and mark a server up or down based on the response.

--- a/pkg/vcdswaggerclient_37_2/model_edge_load_balancer_pool_modified.go
+++ b/pkg/vcdswaggerclient_37_2/model_edge_load_balancer_pool_modified.go
@@ -37,7 +37,7 @@ type EdgeLoadBalancerPool struct {
 	// The destination server port used by the traffic sent to the member.
 	DefaultPort int32 `json:"defaultPort,omitempty"`
 	// Maximum time (in minutes) to gracefully disable a member. Virtual service waits for the specified time before terminating the existing connections to the members that are disabled. <code>Special values: 0 represents 'Immediate', -1 represents 'Infinite'.</code> 
-	GracefulTimeoutPeriod int32 `json:"gracefulTimeoutPeriod,omitempty"`
+	GracefulTimeoutPeriod int32 `json:"gracefulTimeoutPeriod"`
 	// The algorithm for choosing a member within the pool's list of available members for each new connection. Default value is \"LEAST_CONNECTIONS\". Supported algorithms are: <ul> <li>LEAST_CONNECTIONS <li>ROUND_ROBIN <li>CONSISTENT_HASH <li>FASTEST_RESPONSE <li>LEAST_LOAD <li>FEWEST_SERVERS <li>RANDOM <li>FEWEST_TASKS <li>CORE_AFFINITY </ul> <em>CONSISTENT_HASH</em> uses Source IP Address hash. Using <em>FASTEST_RESPONSE</em>, <em>LEAST_LOAD</em>, <em>FEWEST_SERVERS</em>, <em>RANDOM</em>, <em>FEWEST_TASKS</em>, <em>CORE_AFFINITY</em> algorithms requires an Edge Gateway Load Balancer with PREMIUM feature set. 
 	Algorithm string `json:"algorithm,omitempty"`
 	// Member server's health can be monitored by using one or more health monitors. Active monitors generate synthetic traffic and mark a server up or down based on the response. 


### PR DESCRIPTION
The issue was that, for one particular case in LB pool creation, we would use 0 to indicate that the graceful disable timeout would be immediate. However 0 is a null value and the omitempty was dropping the field. Since the field was dropped, VCD API server was treating the value as not sent, and using the default value for this parameter which was 1. Hence the intended graceful disable timeout was never set up.
The change is to remove all omitempty values. The core advantage of omitempty is in messaging systems where message size is important. So reducing the unnecessary fields will help make messaging smaller. In the case of the VCD API, we don't need to have optimized messages. However accuracy is key. Thus, removing the omitempty globally will not cause much harm but will ensure that code works as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/311)
<!-- Reviewable:end -->
