### PR TITLE
[Cherrypick][VKCI-237][Testing] Poll for RDE updates instead of immediate failure (#314)

### DIFF
--- a/tests/e2e/utils/cpi_rde_utils.go
+++ b/tests/e2e/utils/cpi_rde_utils.go
@@ -13,10 +13,8 @@ func IsExternalIpInVCDResourceSet(ctx context.Context, tc *testingsdk.TestClient
 		return false, fmt.Errorf("error retrieving virtual ips from VCDResourceSet in [%s] status: [%v]", vcdsdk.ComponentCPI, err)
 	}
 
-	if virtualIps.Contains(externalIp) {
-		return true, nil
-	}
-	return false, fmt.Errorf("external ip [%s] does not exist in VCDResourceSet from [%s]", externalIp, vcdsdk.ComponentCPI)
+	// Instead of returning an error when it doesn't contain the IP, we will let the test assertion decide.
+	return virtualIps.Contains(externalIp), nil
 }
 
 func getVirtualIpsFromRDE(ctx context.Context, client *vcdsdk.Client, clusterId string) (*testingsdk.Set, error) {


### PR DESCRIPTION
* Poll for RDE updates instead of immediate failure
* Remove error return to let test assertion decide



---------

Cherrypick 85d974d from main

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/316)
<!-- Reviewable:end -->
