### PR TITLE
[VCDA-6990] Update dependencies.txt.template to use vmware-cloud-director for image path

### DIFF
--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -11,7 +11,7 @@
 		"binaries": [],
 		"dependencies": [
 			{
-				"name":"cloud-provider-for-cloud-director",
+				"name":"vmware-cloud-director/cloud-provider-for-cloud-director",
 				"version":"__VERSION__",
 				"imageRepository":"__REGISTRY__"
 			}

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,1 +1,1 @@
-__REGISTRY__ cloud-provider-for-cloud-director __VERSION__
+__REGISTRY__ vmware-cloud-director/cloud-provider-for-cloud-director __VERSION__


### PR DESCRIPTION
Updates dependencies.txt.template to use 'vmware-cloud-director/cluster-api-provider-cloud-director' as part of image path for consistency

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/332)
<!-- Reviewable:end -->
