### PR TITLE
VKCI-281,282: Simplify VM creation and ExtraConfig updates

### DIFF
--- a/pkg/vcdsdk/vm_types.go
+++ b/pkg/vcdsdk/vm_types.go
@@ -29,7 +29,6 @@ type Vm struct {
 	VmSpecSection                     *VmSpecSection                     `xml:"VmSpecSection,omitempty"`
 	ExtraConfigVirtualHardwareSection *ExtraConfigVirtualHardwareSection `xml:"VirtualHardwareSection,omitempty"`
 	NetworkConnectionSection          *NetworkConnectionSection          `xml:"NetworkConnectionSection,omitempty"`
-	IsVAppConfigRemoved               bool                               `xml:"IsVAppConfigRemoved,omitempty"`
 }
 
 type VmMarshal struct {

--- a/pkg/vcdsdk/vm_types.go
+++ b/pkg/vcdsdk/vm_types.go
@@ -29,6 +29,7 @@ type Vm struct {
 	VmSpecSection                     *VmSpecSection                     `xml:"VmSpecSection,omitempty"`
 	ExtraConfigVirtualHardwareSection *ExtraConfigVirtualHardwareSection `xml:"VirtualHardwareSection,omitempty"`
 	NetworkConnectionSection          *NetworkConnectionSection          `xml:"NetworkConnectionSection,omitempty"`
+	IsVAppConfigRemoved               bool                               `xml:"IsVAppConfigRemoved,omitempty"`
 }
 
 type VmMarshal struct {


### PR DESCRIPTION
1. VM creation was nested and using redundant APIs to get the same information. 
2. VM creation had some complex logic around multi-VM creation and power-on. Those were added by me and the intern a long time ago, but they are not relevant now. They also hinder readability and ability to maintain and add new code.
3. ExtraConfig update updates one config at a time and each update is slow. They can be batched. (For a single-config update, one can use a single-element map).
4. There were some functions that were blocking with the task. Now these functions are essentially asynchronous with the task being returned to the caller. It is a simple pattern to block in the caller.
5. Some basic decomposition into functions to help readability.

All of the changes are in the common core. They affect caller codepaths on CSE and CAPVCD. Those will be handled by commits in those projects separately.

All of the above are tested by a small test written in the PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/333)
<!-- Reviewable:end -->
