### PR TITLE
VKCI-254,255,257: look at multiple OVDCs in order to register the VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ SHELLCHECK ?= bin/shellcheck
 all: vendor lint dev
 
 .PHONY: cpi
-capvcd: vendor lint docker-build-cpi ## Run checks, and build cpi docker image.
+cpi: vendor lint docker-build-cpi ## Run checks, and build cpi docker image.
 
 ##@ General
 

--- a/manifests/vcloud-configmap.yaml
+++ b/manifests/vcloud-configmap.yaml
@@ -9,6 +9,7 @@ data:
       host: VCD_HOST
       org: ORG
       vdc: OVDC
+      isZoneEnabledCluster: false # set true if zones are to be used
     loadbalancer:
       oneArm:
         startIP: "192.168.8.2"

--- a/pkg/ccm/common.go
+++ b/pkg/ccm/common.go
@@ -1,0 +1,15 @@
+package ccm
+
+import (
+	"fmt"
+	"strings"
+)
+
+func getUUIDFromProviderID(providerID string) string {
+	withoutPrefix := strings.TrimPrefix(providerID, ProviderName+"://")
+	return strings.ToLower(strings.TrimSpace(withoutPrefix))
+}
+
+func getProviderIDFromUUID(vmUUID string) string {
+	return fmt.Sprintf("%s://%s", ProviderName, vmUUID)
+}

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -12,23 +12,22 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	cloudProvider "k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog"
 	"runtime/debug"
-	"strings"
 )
 
 type instances struct {
 	vmInfoCache *VmInfoCache
 }
 
-func newInstances(vmInfoCache *VmInfoCache) cloudProvider.Instances {
-	return &instances{vmInfoCache}
+// Instances returns an instances interface. Also returns true if the interface is supported, false otherwise.
+func (vcdCP *VCDCloudProvider) Instances() (cloudprovider.Instances, bool) {
+	return vcdCP.instances, true
 }
 
-func getUUIDFromProviderID(providerID string) string {
-	withoutPrefix := strings.TrimPrefix(providerID, ProviderName+"://")
-	return strings.ToLower(strings.TrimSpace(withoutPrefix))
+func newInstances(vmInfoCache *VmInfoCache) cloudprovider.Instances {
+	return &instances{vmInfoCache}
 }
 
 // NodeAddresses returns the addresses of the specified instance.
@@ -39,7 +38,7 @@ func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) 
 	vmInfo, err := i.vmInfoCache.GetByName(vmName)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
-			return nil, cloudProvider.InstanceNotFound
+			return nil, cloudprovider.InstanceNotFound
 		}
 
 		return nil, fmt.Errorf("unable to find node addresses for [%s]: [%v]", vmName, err)
@@ -64,7 +63,7 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 	vmInfo, err := i.vmInfoCache.GetByUUID(vmUUID)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
-			return nil, cloudProvider.InstanceNotFound
+			return nil, cloudprovider.InstanceNotFound
 		}
 
 		return nil, fmt.Errorf("unable to find node addresses by vm UUID for [%s]: [%v]", vmUUID, err)
@@ -83,7 +82,7 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 	vmInfo, err := i.vmInfoCache.GetByName(vmName)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
-			return "", cloudProvider.InstanceNotFound
+			return "", cloudprovider.InstanceNotFound
 		}
 
 		return "", fmt.Errorf("unable to find instance ID from vm name [%s]: [%v]", vmName, err)
@@ -100,7 +99,7 @@ func (i *instances) InstanceType(ctx context.Context, nodeName types.NodeName) (
 	vmInfo, err := i.vmInfoCache.GetByName(vmName)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
-			return "", cloudProvider.InstanceNotFound
+			return "", cloudprovider.InstanceNotFound
 		}
 
 		return "", fmt.Errorf("unable to find instance type from vm name [%s]: [%v]", vmName, err)
@@ -117,7 +116,7 @@ func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 	vmInfo, err := i.vmInfoCache.GetByUUID(vmUUID)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
-			return "", cloudProvider.InstanceNotFound
+			return "", cloudprovider.InstanceNotFound
 		}
 
 		return "", fmt.Errorf("unable to find instance type from vm uuid [%s]: [%v]", vmUUID, err)
@@ -130,7 +129,7 @@ func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 // expected format for the key is standard ssh-keygen format: <protocol> <blob>
 func (i *instances) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
 	klog.Infof("vcd.AddSSHKeyToAllInstances() called")
-	return cloudProvider.NotImplemented
+	return cloudprovider.NotImplemented
 }
 
 // CurrentNodeName returns the name of the node we are currently running on

--- a/pkg/ccm/instancesv2.go
+++ b/pkg/ccm/instancesv2.go
@@ -1,9 +1,146 @@
 package ccm
 
 import (
+	"context"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/config"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	v1 "k8s.io/api/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
 )
 
-func (_ *VCDCloudProvider) InstancesV2() (cloudprovider.InstancesV2, bool) {
-	return nil, false
+type instancesV2 struct {
+	vmInfoCache *VmInfoCache
+	zoneMap     *config.ZoneMap
+}
+
+func (vcdCP *VCDCloudProvider) InstancesV2() (cloudprovider.InstancesV2, bool) {
+	return vcdCP.instancesV2, true
+}
+
+func newInstancesV2(vmInfoCache *VmInfoCache, zoneMap *config.ZoneMap) cloudprovider.InstancesV2 {
+	return instancesV2{
+		vmInfoCache: vmInfoCache,
+		zoneMap:     zoneMap,
+	}
+}
+
+// InstanceExists returns true if the instance for the given node exists according to the cloud provider.
+// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
+func (i instancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+	vmName := node.Name
+	vmId := node.Spec.ProviderID
+	klog.Infof("instances.InstanceShutdown called with vmName [%s], vmId [%s]", vmName, vmId)
+	switch {
+	case vmName != "":
+		_, err := i.vmInfoCache.GetByName(vmName)
+		if err != nil {
+			if err == govcd.ErrorEntityNotFound {
+				return false, cloudprovider.InstanceNotFound
+			}
+			return false, fmt.Errorf("unable to find instance ID from vm name [%s]: [%v]", vmName, err)
+		}
+		return true, nil
+
+	case vmId != "":
+		_, err := i.vmInfoCache.GetByUUID(vmId)
+		if err != nil {
+			if err == govcd.ErrorEntityNotFound {
+				return false, cloudprovider.InstanceNotFound
+			}
+			return false, fmt.Errorf("unable to find instance ID from vm Id [%s]: [%v]", vmId, err)
+		}
+		return true, nil
+
+	default:
+		return false, fmt.Errorf("both vm name and vm UUID are not specified")
+	}
+}
+
+// InstanceShutdown returns true if the instance is shutdown according to the cloud provider.
+// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
+func (i instancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	providerID := node.Spec.ProviderID
+	klog.Infof("instances.InstanceShutdown called with providerID [%s]", providerID)
+
+	vmUUID := getUUIDFromProviderID(providerID)
+	vmInfo, err := i.vmInfoCache.GetByUUID(vmUUID)
+	if err != nil {
+		if err == govcd.ErrorEntityNotFound {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("unable to find instance type from vm uuid [%s]: [%v]", vmUUID, err)
+	}
+
+	if vmInfo.vm == nil {
+		return false, fmt.Errorf("vm struct in vmInfo nil for vm uuid [%s]: [%v]", vmUUID, err)
+	}
+
+	status, err := vmInfo.vm.GetStatus()
+	if err != nil {
+		vdcManager, vdcManagerErr := vcdsdk.NewVDCManager(i.vmInfoCache.client, i.vmInfoCache.client.ClusterOrgName,
+			i.vmInfoCache.client.ClusterOVDCName)
+		if vdcManagerErr != nil {
+			return false, fmt.Errorf("error creating VDC manager object: [%v]", err)
+		}
+		if vdcManager.IsVmNotAvailable(err) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("unable to get status of vm uuid [%s], name [%s]: [%v]",
+			vmUUID, vmInfo.Name, err)
+	}
+	if status == "POWERED_ON" {
+		return false, nil
+	}
+
+	klog.Infof("instances.InstanceShutdownByProviderID() for provider ID [%s] is true", providerID)
+	return true, nil
+}
+
+// InstanceMetadata returns the instance's metadata. The values returned in InstanceMetadata are
+// translated into specific fields and labels in the Node object on registration.
+// Implementations should always check node.spec.providerID first when trying to discover the instance
+// for a given node. In cases where node.spec.providerID is empty, implementations can use other
+// properties of the node like its name, labels and annotations.
+func (i instancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+	providerID := node.Spec.ProviderID
+	klog.Infof("instancesV2.InstanceMetadata called with name [%s], providerID [%s]", node.Name, providerID)
+
+	var vmInfo *VmInfo = nil
+	var err error
+	if providerID != "" {
+		vmUUID := getUUIDFromProviderID(providerID)
+		vmInfo, err = i.vmInfoCache.GetByUUID(vmUUID)
+		if err != nil {
+			return nil, fmt.Errorf("error trying to find VM with name [%s], UUID [%s] by UUID: [%v]",
+				node.Name, vmUUID, err)
+		}
+	} else {
+		vmInfo, err = i.vmInfoCache.GetByName(node.Name)
+		if err != nil {
+			return nil, fmt.Errorf("error trying to fingd VM with name [%s], UUID [%s] by UUID: [%v]",
+				node.Name, "", err)
+		}
+	}
+
+	zone := ""
+	if i.zoneMap != nil {
+		zone, _ = i.zoneMap.VdcToZoneMap[vmInfo.OVDC]
+	}
+
+	instanceMetadata := &cloudprovider.InstanceMetadata{
+		ProviderID:    getProviderIDFromUUID(vmInfo.UUID),
+		InstanceType:  vmInfo.Type,
+		NodeAddresses: vmInfo.Addresses,
+		Zone:          zone,
+		Region:        "",
+	}
+
+	klog.Infof("reporting instanceV2 Metadata for vm [%s] as [%#v]", vmInfo.Name, instanceMetadata)
+
+	return instanceMetadata, nil
 }

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -7,8 +7,10 @@ package ccm
 
 import (
 	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/config"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	"k8s.io/klog"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +21,8 @@ import (
 
 type VmInfo struct {
 	vm        *govcd.VM
+	OVDC      string
+	Zone      string
 	UUID      string
 	Name      string
 	Type      string
@@ -26,7 +30,7 @@ type VmInfo struct {
 	TimeStamp time.Time
 }
 
-// VmInfoCache caches VM details. Ideally we need a LRU cache with ttl-based expiry. But since we have ~10k nodes
+// VmInfoCache caches VM details. Ideally we need an LRU cache with ttl-based expiry. But since we have O(1k) nodes
 // per cluster, we can ignore limits and expiry.
 type VmInfoCache struct {
 	rwLock          sync.RWMutex
@@ -35,19 +39,21 @@ type VmInfoCache struct {
 	uuidMap         map[string]*VmInfo
 	client          *vcdsdk.Client
 	clusterVAppName string
+	zm              *config.ZoneMap
 }
 
-func newVmInfoCache(client *vcdsdk.Client, clusterVAppName string, expiry time.Duration) *VmInfoCache {
+func newVmInfoCache(client *vcdsdk.Client, clusterVAppName string, expiry time.Duration, zm *config.ZoneMap) *VmInfoCache {
 	return &VmInfoCache{
 		expiry:          expiry,
 		nameMap:         make(map[string]*VmInfo),
 		uuidMap:         make(map[string]*VmInfo),
 		client:          client,
 		clusterVAppName: clusterVAppName,
+		zm:              zm,
 	}
 }
 
-func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, captureTime time.Time) (*VmInfo, error) {
+func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, ovdc string, captureTime time.Time) (*VmInfo, error) {
 
 	if vm == nil {
 		return nil, fmt.Errorf("vm parameter should not be nil")
@@ -58,6 +64,7 @@ func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, captureTime time.Time) (*VmInf
 
 	vmInfo := &VmInfo{
 		vm:        vm,
+		OVDC:      ovdc,
 		UUID:      vm.VM.ID,
 		Name:      vm.VM.Name,
 		Type:      "",
@@ -90,6 +97,97 @@ func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, captureTime time.Time) (*VmInf
 	return vmInfo, nil
 }
 
+func CreateVAppNamePrefix(clusterName string, ovdcID string) (string, error) {
+	parts := strings.Split(ovdcID, ":")
+	if len(parts) != 4 {
+		// urn:vcloud:org:<uuid>
+		return "", fmt.Errorf("invalid URN format for OVDC: [%s]", ovdcID)
+	}
+
+	return fmt.Sprintf("%s_%s", clusterName, parts[3]), nil
+}
+
+func (vmic *VmInfoCache) SearchVMAcrossVDCs(vmName string, vmId string) (*govcd.VM, string, error) {
+	if err := vmic.client.RefreshBearerToken(); err != nil {
+		return nil, "", fmt.Errorf("error while obtaining access token: [%v]", err)
+	}
+
+	org, err := vmic.client.VCDClient.GetOrgByName(vmic.client.ClusterOrgName)
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to get org by name [%s]: [%v]", vmic.client.ClusterOrgName, err)
+	}
+
+	var ovdcNameList []string = nil
+	if vmic.zm != nil {
+		for key, _ := range vmic.zm.VdcToZoneMap {
+			ovdcNameList = append(ovdcNameList, key)
+		}
+	} else {
+		ovdcNameList = []string{
+			vmic.client.ClusterOVDCName,
+		}
+	}
+
+	for _, ovdcName := range ovdcNameList {
+		klog.Infof("Looking for VM [name:%s],[id:%s] of cluster [%s] in OVDC [%s]",
+			vmName, vmId, vmic.clusterVAppName, ovdcName)
+
+		vdc, err := org.GetVDCByName(ovdcName, true)
+		if err != nil {
+			klog.Infof("unable to query VDC [%s] in Org [%s] by name: [%v]",
+				ovdcName, vmic.client.ClusterOrgName, err)
+			continue
+		}
+
+		vAppNamePrefix, err := CreateVAppNamePrefix(vmic.clusterVAppName, vdc.Vdc.ID)
+		if err != nil {
+			klog.Infof("Unable to create a vApp name prefix for cluster [%s] in OVDC [%s] with OVDC ID [%s]: [%v]",
+				vmic.clusterVAppName, vdc.Vdc.Name, vdc.Vdc.ID, err)
+			continue
+		}
+
+		klog.Infof("Looking for vApps with a prefix of [%s]", vAppNamePrefix)
+		vAppList := vdc.GetVappList()
+		// check if the VM exists in any cluster-vApps in this OVDC
+		for _, vApp := range vAppList {
+			if strings.HasPrefix(vApp.Name, vAppNamePrefix) {
+				// check if VM exists
+				klog.Infof("Looking for VM [name:%s],[id:%s] in vApp [%s] in OVDC [%s] is a vApp in cluster [%s]",
+					vmName, vmId, vApp.Name, vdc.Vdc.Name, vmic.clusterVAppName)
+				vdcManager, err := vcdsdk.NewVDCManager(vmic.client, vmic.client.ClusterOrgName, vdc.Vdc.Name)
+				if err != nil {
+					return nil, "", fmt.Errorf("error creating VDCManager object for VDC [%s]: [%v]",
+						vdc.Vdc.Name, err)
+				}
+
+				var vm *govcd.VM = nil
+				if vmName != "" {
+					vm, err = vdcManager.FindVMByName(vApp.Name, vmName)
+				} else if vmId != "" {
+					vm, err = vdcManager.FindVMByUUID(vApp.Name, vmId)
+				} else {
+					return nil, "", fmt.Errorf("either vm name [%s] or ID [%s] should be passed", vmName, vmId)
+				}
+				if err != nil {
+					klog.Infof("Could not find VM [name:%s],[id:%s] in vApp [%s] of Cluster [%s] in OVDC [%s]: [%v]",
+						vmName, vmId, vApp.Name, vmic.clusterVAppName, vdc.Vdc.Name, err)
+					continue
+				}
+
+				// If we reach here, we found the VM
+				klog.Infof("Found VM [name:%s],[id:%s] in vApp [%s] of Cluster [%s] in OVDC [%s]: [%v]",
+					vmName, vmId, vApp.Name, vmic.clusterVAppName, vdc.Vdc.Name, err)
+				return vm, vdc.Vdc.Name, nil
+			}
+		}
+
+		klog.Infof("Could not find VM [name:%s],[id:%s] of cluster [%s] in OVDC [%s]",
+			vmName, vmId, vmic.clusterVAppName, ovdcName)
+	}
+
+	return nil, "", govcd.ErrorEntityNotFound
+}
+
 func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 	vmic.rwLock.Lock()
 	defer vmic.rwLock.Unlock()
@@ -105,28 +203,13 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 		delete(vmic.nameMap, vmName)
 	}
 
-	captureTime := time.Now()
-	if err := vmic.client.RefreshBearerToken(); err != nil {
-		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
-	}
-	vdcManager, err := vcdsdk.NewVDCManager(vmic.client, vmic.client.ClusterOrgName, vmic.client.ClusterOVDCName)
+	vm, ovdcName, err := vmic.SearchVMAcrossVDCs(vmName, "")
 	if err != nil {
-		return nil, fmt.Errorf("error creating VDCManager object: [%v]", err)
-	}
-	vm, err := vdcManager.FindVMByName(vmic.clusterVAppName, vmName)
-	if err != nil {
-		if err == govcd.ErrorEntityNotFound {
-			return nil, govcd.ErrorEntityNotFound
-		}
-
-		if vdcManager.IsVmNotAvailable(err) {
-			return nil, govcd.ErrorEntityNotFound
-		}
-
-		return nil, fmt.Errorf("unable to find vm with name [%s]: [%v]", vmName, err)
+		return nil, fmt.Errorf("unable to find VM [%s] in org [%s] for cluster [%s]: [%v]",
+			vmName, vmic.client.ClusterOrgName, vmic.clusterVAppName, err)
 	}
 
-	vmInfo, err := vmic.vmToVMInfo(vm, captureTime)
+	vmInfo, err := vmic.vmToVMInfo(vm, ovdcName, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert vm struct [%v] to vmInfo: [%v]", vm, err)
 	}
@@ -151,35 +234,19 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 		// don't use old values
 		delete(vmic.nameMap, vmUUID)
 	}
-
-	captureTime := time.Now()
-	if err := vmic.client.RefreshBearerToken(); err != nil {
-		return nil, fmt.Errorf("error while obtaining access token: [%v]", err)
-	}
-	vdcManager, err := vcdsdk.NewVDCManager(vmic.client, vmic.client.ClusterOrgName, vmic.client.ClusterOVDCName)
+	vm, ovdcName, err := vmic.SearchVMAcrossVDCs("", vmUUID)
 	if err != nil {
-		return nil, fmt.Errorf("error creating VDCManager object: [%v]", err)
-	}
-	vm, err := vdcManager.FindVMByUUID(vmic.clusterVAppName, vmUUID)
-	if err != nil {
-		if err == govcd.ErrorEntityNotFound {
-			return nil, govcd.ErrorEntityNotFound
-		}
-
-		if vdcManager.IsVmNotAvailable(err) {
-			return nil, govcd.ErrorEntityNotFound
-		}
-
-		return nil, fmt.Errorf("unable to find vm with uuid [%s]: [%v]", vmUUID, err)
+		return nil, fmt.Errorf("unable to find VM [%s] in org [%s] for cluster [%s]: [%v]",
+			vmUUID, vmic.client.ClusterOrgName, vmic.clusterVAppName, err)
 	}
 
-	vmInfo, err := vmic.vmToVMInfo(vm, captureTime)
+	vmInfo, err := vmic.vmToVMInfo(vm, ovdcName, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert vm struct [%v] to vmInfo: [%v]", vm, err)
 	}
 
-	vmic.uuidMap[vmUUID] = vmInfo
-	vmic.nameMap[vm.VM.Name] = vmInfo
+	vmic.nameMap[vmUUID] = vmInfo
+	vmic.uuidMap[vm.VM.ID] = vmInfo
 
 	return vmInfo, nil
 }

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -8,9 +8,8 @@ package config
 import (
 	"fmt"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	"io"
-	"io/ioutil"
 	"k8s.io/klog"
 	"os"
 	"strings"
@@ -18,13 +17,14 @@ import (
 
 // VCDConfig :
 type VCDConfig struct {
-	Host    string `yaml:"host"`
-	VDC     string `yaml:"vdc"`
-	Org     string `yaml:"org"`
-	UserOrg string // this defaults to Org or a prefix of User
+	Host                 string `yaml:"host"`
+	VDC                  string `yaml:"vdc,omitempty"`
+	Org                  string `yaml:"org"`
+	UserOrg              string // this defaults to Org or a prefix of User
+	IsZoneEnabledCluster bool   `yaml:"isZoneEnabledCluster"`
 
 	// It is allowed to pass the following variables using the config. However,
-	// that is unsafe security practice. However there can be user scenarios and
+	// that is unsafe security practice. However, there can be user scenarios and
 	// testing scenarios where this is sensible.
 
 	// The User, Secret and RefreshToken are obtained from a secret mounted to /etc/kubernetes/vcloud/basic-auth
@@ -96,14 +96,14 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 }
 
 func SetAuthorization(config *CloudConfig) error {
-	refreshToken, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
+	refreshToken, err := os.ReadFile("/etc/kubernetes/vcloud/basic-auth/refreshToken")
 	if err != nil {
 		klog.Infof("Unable to get refresh token: [%v]", err)
 	} else {
 		config.VCD.RefreshToken = strings.TrimSuffix(string(refreshToken), "\n")
 	}
 
-	username, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
+	username, err := os.ReadFile("/etc/kubernetes/vcloud/basic-auth/username")
 	if err != nil {
 		klog.Infof("Unable to get username: [%v]", err)
 	} else {
@@ -119,7 +119,7 @@ func SetAuthorization(config *CloudConfig) error {
 		config.VCD.UserOrg = strings.TrimSuffix(config.VCD.Org, "\n")
 	}
 
-	secret, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
+	secret, err := os.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
 	if err != nil {
 		klog.Infof("Unable to get password: [%v]", err)
 	} else {

--- a/pkg/config/zonemap.go
+++ b/pkg/config/zonemap.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"k8s.io/klog/v2"
+	"os"
+	"sync"
+)
+
+const (
+	ZoneMapConfigFilePath = "/opt/vmware-cloud-director/ccm/vcloud-cse-zones.yaml"
+)
+
+type ZoneMap struct {
+	rwLock        sync.RWMutex
+	configMapFile string
+	VdcToZoneMap  map[string]string
+}
+
+type Zone struct {
+	Name     string `yaml:"name"`
+	OVDCName string `yaml:"ovdcName"`
+}
+
+type ZoneConfigMap struct {
+	ZoneType string `yaml:"zoneType"`
+	Zones    []Zone `yaml:"zones"`
+}
+
+func NewZoneMap(configMapFile string) (*ZoneMap, error) {
+	zm := &ZoneMap{
+		configMapFile: configMapFile,
+		VdcToZoneMap:  make(map[string]string),
+	}
+
+	if err := zm.ReloadZoneMap(); err != nil {
+		return nil, fmt.Errorf("unable to load and parse configmap [%s]: [%v]", configMapFile, err)
+	}
+
+	return zm, nil
+}
+
+func (zm *ZoneMap) ReloadZoneMap() error {
+	configFileReader, err := os.Open(zm.configMapFile)
+	if err != nil {
+		return fmt.Errorf("unable to open file [%s]: [%v]", zm.configMapFile, err)
+	}
+	defer func() {
+		if err := configFileReader.Close(); err != nil {
+			klog.Infof("unable to close config map file [%s]: [%v]", zm.configMapFile, err)
+		}
+	}()
+
+	zoneConfigMap := &ZoneConfigMap{
+		ZoneType: "",
+	}
+	decoder := yaml.NewDecoder(configFileReader)
+	decoder.SetStrict(true)
+	if err = decoder.Decode(&zoneConfigMap); err != nil {
+		return fmt.Errorf("unable to decode zone configmap [%s]: [%v]", zm.configMapFile, err)
+	}
+
+	zm.rwLock.Lock()
+	defer zm.rwLock.Unlock()
+
+	for _, zone := range zoneConfigMap.Zones {
+		zm.VdcToZoneMap[zone.OVDCName] = zone.Name
+	}
+
+	return nil
+}

--- a/pkg/vcdsdk/vapp.go
+++ b/pkg/vcdsdk/vapp.go
@@ -313,9 +313,8 @@ func (vdc *VdcManager) FindVMByName(VAppName string, vmName string) (*govcd.VM, 
 		return nil, fmt.Errorf("vmName mandatory for FindVMByName")
 	}
 
-	client := vdc.Client
 	klog.Infof("Trying to find vm [%s] in vApp [%s] by name", vmName, VAppName)
-	vApp, err := client.VDC.GetVAppByName(VAppName, true)
+	vApp, err := vdc.Vdc.GetVAppByName(VAppName, true)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find vApp [%s] by name: [%v]", VAppName, err)
 	}


### PR DESCRIPTION
This change brings in a the multiAZ aspect to the CPI. The CPI registers nodes, and the nodes are in multiple vApps. So the vApps need to be discovered in multiple OVDCs. The representation of OVDCs is in a configmap which has the following example format
```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: vcloud-capvcd-zones
  namespace: kube-system
data:
  vcloud-cse-zones.yaml: |+
    zoneType: dcgroup
    zones:
    - name: zone1
      ovdcName: <ovdc of zone1>
    - name: zone2
      ovdcName: <ovdc of zone2>
    - name: zone3
      ovdcName: <ovdc of zone3>
---
```

To trigger usage of this zoneMap, and also to ensure backward compatibility, this feature is triggered by a flag in the CPI configmap variable `isZoneEnabledCluster`:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: vcloud-ccm-configmap
  namespace: kube-system
data:
  vcloud-ccm-config.yaml: |+
    vcd:
      host: <vcd api endpoint>
      org: orgName
      vdc: ovdcName
      isZoneEnabledCluster: true
```

In order to be able to add the label `topology.k8s.io/zones`, CPI needs the `InstancesV2` interface to be implemented. That is part of this PR as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/335)
<!-- Reviewable:end -->
