### PR TITLE
[VCDA-6932] Consolidate makefile with all the necessary targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,13 +103,13 @@ integration-test: test
 .PHONY: gobuild
 gobuild: vendor manifests release-prep build docker-build docker-archive publish
 
-.PHONY: sandbox
+.PHONY: dev-build
 # BUILD_TAG will be set during the build so it is not defined as it's not expected to be used by anything else here.
-sandbox: VERSION := $(VERSION)-${BUILD_TAG}-$(GITCOMMIT)
-sandbox: gobuild
+dev-build: VERSION := $(VERSION)-${BUILD_TAG}-$(GITCOMMIT)
+dev-build: gobuild
 
-.PHONY: official
-official: gobuild
+.PHONY: rc-build
+rc-build: gobuild
 
 # docker-archive target saves the artifacts as .tar.gz to build/docker path which gets published as deliverables.
 .PHONY: docker-archive

--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,14 @@ integration-test: test
 gobuild: vendor manifests release-prep build docker-build docker-archive publish
 
 .PHONY: sandbox
+# BUILD_TAG will be set during the build so it is not defined as it's not expected to be used by anything else here.
 sandbox: VERSION := $(VERSION)-${BUILD_TAG}-$(GITCOMMIT)
 sandbox: gobuild
 
 .PHONY: official
 official: gobuild
 
-# docker-archive target saves the artifacts as tar.gz as part of the deliverables
+# docker-archive target saves the artifacts as .tar.gz as part of the deliverables
 .PHONY: docker-archive
 docker-archive: build/docker
 	docker save -o build/docker/$(CPI_IMG)_$(VERSION).tar projects-stg.registry.vmware.com/vmware-cloud-director/$(CPI_IMG):$(VERSION)
@@ -118,7 +119,7 @@ docker-archive: build/docker
 	gzip build/docker/$(CPI_IMG)_$(VERSION).tar
 	gzip build/docker/$(ARTIFACT_IMG)_$(VERSION).tar
 
-# publish target publishes all the contents inside of build/docker
+# publish target publishes all the contents inside of build/docker. PUBLISH_DIR will be set during the build so it is not defined.
 .PHONY: publish
 publish:
 	cp -R build/docker ${PUBLISH_DIR}

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ rc-build: gobuild
 
 # docker-archive target saves the artifacts as .tar.gz to build/docker path which gets published as deliverables.
 .PHONY: docker-archive
-docker-archive: build/docker
+docker-archive:
+	mkdir -p build/docker
 	docker save -o build/docker/$(CPI_IMG)_$(VERSION).tar projects-stg.registry.vmware.com/vmware-cloud-director/$(CPI_IMG):$(VERSION)
 	docker save -o build/docker/$(ARTIFACT_IMG)_$(VERSION).tar projects-stg.registry.vmware.com/vmware-cloud-director/$(ARTIFACT_IMG):$(VERSION)
 	gzip build/docker/$(CPI_IMG)_$(VERSION).tar
@@ -123,10 +124,6 @@ docker-archive: build/docker
 .PHONY: publish
 publish:
 	cp -R build/docker ${PUBLISH_DIR}
-
-# build/docker is used as part of the gobuild process. In the end, we publish everything inside this folder. See target publish.
-build/docker:
-	mkdir -p build/docker
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ rc-build: gobuild
 .PHONY: docker-archive
 docker-archive:
 	mkdir -p build/docker
-	docker save -o build/docker/$(CPI_IMG)_$(VERSION).tar projects-stg.registry.vmware.com/vmware-cloud-director/$(CPI_IMG):$(VERSION)
-	docker save -o build/docker/$(ARTIFACT_IMG)_$(VERSION).tar projects-stg.registry.vmware.com/vmware-cloud-director/$(ARTIFACT_IMG):$(VERSION)
+	docker save -o build/docker/$(CPI_IMG)_$(VERSION).tar $(CPI_IMG):$(VERSION)
+	docker save -o build/docker/$(ARTIFACT_IMG)_$(VERSION).tar $(ARTIFACT_IMG):$(VERSION)
 	gzip build/docker/$(CPI_IMG)_$(VERSION).tar
 	gzip build/docker/$(ARTIFACT_IMG)_$(VERSION).tar
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ sandbox: gobuild
 .PHONY: official
 official: gobuild
 
-# docker-archive target saves the artifacts as .tar.gz as part of the deliverables
+# docker-archive target saves the artifacts as .tar.gz to build/docker path which gets published as deliverables.
 .PHONY: docker-archive
 docker-archive: build/docker
 	docker save -o build/docker/$(CPI_IMG)_$(VERSION).tar projects-stg.registry.vmware.com/vmware-cloud-director/$(CPI_IMG):$(VERSION)


### PR DESCRIPTION
* Updates the Makefile with all the necessary targets that will only be used for gobuild

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/337)
<!-- Reviewable:end -->
