### PR TITLE
[VKCI-285] update DeleteVM() function to make it asynchronous

### DIFF
--- a/pkg/vcdsdk/vapp.go
+++ b/pkg/vcdsdk/vapp.go
@@ -750,22 +750,23 @@ func (vdc *VdcManager) AddNewVM(vmName string, VAppName string, catalogName stri
 	return task, nil
 }
 
-func (vdc *VdcManager) DeleteVM(VAppName, vmName string) error {
+func (vdc *VdcManager) DeleteVM(VAppName, vmName string) (govcd.Task, error) {
 	vApp, err := vdc.Vdc.GetVAppByName(VAppName, true)
 	if err != nil {
-		return fmt.Errorf("unable to find vApp from name [%s]: [%v]", VAppName, err)
+		return govcd.Task{}, fmt.Errorf("unable to find vApp from name [%s]: [%v]", VAppName, err)
 	}
 
 	vm, err := vApp.GetVMByName(vmName, true)
 	if err != nil {
-		return fmt.Errorf("unable to get vm [%s] in vApp [%s]: [%v]", vmName, VAppName, err)
+		return govcd.Task{}, fmt.Errorf("unable to get vm [%s] in vApp [%s]: [%v]", vmName, VAppName, err)
 	}
 
-	if err = vm.Delete(); err != nil {
-		return fmt.Errorf("unable to delete vm [%s] in vApp [%s]: [%v]", vmName, VAppName, err)
+	task, err := vm.DeleteAsync()
+	if err != nil {
+		return govcd.Task{}, fmt.Errorf("unable to delete vm [%s] in vApp [%s]: [%v]", vmName, VAppName, err)
 	}
 
-	return nil
+	return task, nil
 }
 
 func (vdc *VdcManager) GetVAppNameFromVMName(VAppName string, vmName string) (string, error) {


### PR DESCRIPTION
DeleteVM() function currently waits on the delete VM task to complete before it returns.
This change will make DeleteVM() asynchronous and also returns the task object for the caller to help poll the delete VM task status

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/338)
<!-- Reviewable:end -->
