### PR TITLE
VKCI-284: Use the same character-set as VCD for passwords

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,10 +10,18 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	passwordgenerator "github.com/sethvargo/go-password/password"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
 	"io/ioutil"
 	"net/http"
+)
+
+const (
+	VCDLowerLetters = `abcdefghijkmnopqrstuvwxyz`
+	VCDUpperLetters = `ABCDEFGHIJKLMNPQRSTUVWXYZ`
+	VCDDigits       = `23456789`
+	VCDSymbols      = `!$#%`
 )
 
 // indentJsonBody indents raw JSON body for easier readability
@@ -62,4 +70,30 @@ func DecodeXMLBody(bodyType types.BodyType, resp *http.Response, out interface{}
 	}
 
 	return nil
+}
+
+func GeneratePassword(length int, numDigits int, numSymbols int, noUpper bool, allowRepeat bool) (string, error) {
+
+	// these are the inputs used by VMware Cloud Director
+	generatorInput := passwordgenerator.GeneratorInput{
+		LowerLetters: VCDLowerLetters,
+		UpperLetters: VCDUpperLetters,
+		Digits:       VCDDigits,
+		Symbols:      VCDSymbols,
+		Reader:       nil,
+	}
+
+	passwordGenerator, err := passwordgenerator.NewGenerator(&generatorInput)
+	if err != nil {
+		return "", fmt.Errorf("unable to create password generator with character-set [%v]: [%v]",
+			generatorInput, err)
+	}
+
+	passwd, err := passwordGenerator.Generate(length, numDigits, numSymbols, noUpper, allowRepeat)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate a password with character-set [%v]: [%v]",
+			generatorInput, err)
+	}
+
+	return passwd, nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,53 @@
+/*
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestGeneratePassword(t *testing.T) {
+	allowedLowerLettersList := strings.Split(VCDLowerLetters, "")
+	allowedUpperLettersList := strings.Split(VCDUpperLetters, "")
+	allowedDigitsList := strings.Split(VCDDigits, "")
+	allowedSymbolsList := strings.Split(VCDSymbols, "")
+
+	lst := append(allowedLowerLettersList, allowedUpperLettersList...)
+	lst = append(lst, allowedDigitsList...)
+	lst = append(lst, allowedSymbolsList...)
+
+	allowedNumDigits := 2
+	allowedNumSymbols := 3
+	passwd, err := GeneratePassword(10, allowedNumDigits, allowedNumSymbols, false, false)
+	assert.NoError(t, err, "should be able to generate a password with the character set")
+	fmt.Printf("password is [%s]", passwd)
+
+	charSet := NewSet(lst)
+	digitsSet := NewSet(allowedDigitsList)
+	symbolsSet := NewSet(allowedSymbolsList)
+	numDigits := 0
+	numSymbols := 0
+
+	for _, c := range strings.Split(passwd, "") {
+		if !charSet.Contains(c) {
+			assert.Fail(t, "character set [%v] does not contain character [%v]", charSet, c)
+		}
+		if digitsSet.Contains(c) {
+			numDigits++
+		}
+		if symbolsSet.Contains(c) {
+			numSymbols++
+		}
+	}
+
+	assert.LessOrEqual(t, allowedNumDigits, numDigits, "password has unexpected number of digits")
+	assert.LessOrEqual(t, allowedNumSymbols, numSymbols, "password has unexpected number of symbols")
+
+	return
+}

--- a/pkg/vcdsdk/vapp.go
+++ b/pkg/vcdsdk/vapp.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/sethvargo/go-password/password"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/util"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"io/ioutil"
@@ -676,7 +676,8 @@ func (vdc *VdcManager) AddNewVM(vmName string, VAppName string, catalogName stri
 			vdc.VdcName, err)
 	}
 
-	passwd, err := password.Generate(15, 5, 3, false, false)
+	// these are the settings used in VMware Cloud Director
+	passwd, err := util.GeneratePassword(15, 5, 3, false, false)
 	if err != nil {
 		return govcd.Task{}, fmt.Errorf("failed to generate a password to create a VM in the VApp [%s]", vApp.VApp.Name)
 	}


### PR DESCRIPTION
Tested using a unit test. This follows VMware Cloud Director specifications.

(Sample password is `%#w9Q83uP!kq7R6`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/339)
<!-- Reviewable:end -->
