### PR TITLE
[x-port][VKCI-292] Implement method to fetch Ip Spaces associated with a gateway (#343)

### DIFF
--- a/pkg/vcdsdk/common_system_test.go
+++ b/pkg/vcdsdk/common_system_test.go
@@ -103,6 +103,8 @@ func getTestVCDClient(vcdConfig *VcdConfig, inputMap map[string]interface{}) (*C
 				vcdConfigCopy.Host = getStrValStrict(val, vcdConfigCopy.Host)
 			case "org":
 				vcdConfigCopy.TenantOrg = getStrValStrict(val, vcdConfigCopy.TenantOrg)
+			case "vdc":
+				vcdConfigCopy.TenantVdc = getStrValStrict(val, vcdConfigCopy.TenantVdc)
 			case "user":
 				vcdConfigCopy.User = getStrValStrict(val, vcdConfigCopy.User)
 			case "secret":

--- a/pkg/vcdsdk/ip_spaces_test.go
+++ b/pkg/vcdsdk/ip_spaces_test.go
@@ -7,11 +7,13 @@ package vcdsdk
 
 import (
 	"context"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -29,8 +31,10 @@ func TestGatewayUsingIpSpaces(t *testing.T) {
 
 	vcdClient, err := getTestVCDClient(vcdConfig, map[string]interface{}{
 		"user":         testData.Username,
-		"refreshToken": testData.RefreshToken,
 		"userOrg":      testData.UserOrg,
+		"refreshToken": testData.RefreshToken,
+		"org":          testData.UserOrg,
+		"vdc":          testData.Orgvdc,
 		"getVdcClient": true,
 	})
 	assert.NoError(t, err, "Unable to get VCD client")
@@ -51,4 +55,46 @@ func TestGatewayUsingIpSpaces(t *testing.T) {
 	result, err = gm2.IsUsingIpSpaces()
 	assert.NoErrorf(t, err, "Error calling method IsUsingIpSpaces for network %s", testData.OrgvdcNetworkNoIpSpace)
 	assert.False(t, result)
+}
+
+func TestFetchIpSpacesBackingGateway(t *testing.T) {
+	vcdConfig, err := getTestVCDConfig()
+	assert.NoError(t, err, "There should be no error opening and parsing vcd info file contents.")
+
+	testDataFile := filepath.Join(gitRoot, "testdata/ip_space_test.yaml")
+	testDataFileContent, err := os.ReadFile(testDataFile)
+	assert.NoError(t, err, "There should be no error reading the ip space test data file contents.")
+
+	var testData ipSpaceDetails
+	err = yaml.Unmarshal(testDataFileContent, &testData)
+	assert.NoError(t, err, "There should be no error parsing ip space test data file content.")
+
+	vcdClient, err := getTestVCDClient(vcdConfig, map[string]interface{}{
+		"user":         testData.Username,
+		"userOrg":      testData.UserOrg,
+		"refreshToken": testData.RefreshToken,
+		"org":          testData.UserOrg,
+		"vdc":          testData.Orgvdc,
+		"getVdcClient": true,
+	})
+	assert.NoError(t, err, "Unable to get VCD client")
+	require.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	ctx := context.Background()
+
+	gm, err := NewGatewayManager(ctx, vcdClient, testData.OrgvdcNetworkIpSpace, "", testData.Orgvdc)
+	assert.NoErrorf(t, err, "Unable to create Gateway Manager for network %s", testData.OrgvdcNetworkIpSpace)
+
+	fmt.Println("Calling FetchIpSpacesBackingGateway for gateway using Ip Spaces")
+	result, err := gm.FetchIpSpacesBackingGateway(ctx)
+	assert.NoErrorf(t, err, "Error calling method FetchIpSpacesBackingGateway for netowrk %s", testData.OrgvdcNetworkIpSpace)
+	assert.Greater(t, len(result), 0)
+
+	gm2, err := NewGatewayManager(ctx, vcdClient, testData.OrgvdcNetworkNoIpSpace, "", testData.Orgvdc)
+	assert.NoErrorf(t, err, "Unable to create Gateway Manager for network %s", testData.OrgvdcNetworkNoIpSpace)
+
+	fmt.Println("Calling FetchIpSpacesBackingGateway for gateway using Ip blocks")
+	result, err = gm2.FetchIpSpacesBackingGateway(ctx)
+	assert.Error(t, err, "Expected error calling method IsUsingIpSpaces for network %s", testData.OrgvdcNetworkNoIpSpace)
+	assert.True(t, strings.Contains(err.Error(), "403 Forbidden"), "Expected '403 forbidden' message in error found %s", err.Error())
 }


### PR DESCRIPTION
Added method FetchIpSpacesBackingGateway to gateway.go

Testing done:
Added test TestFetchIpSpacesBackingGateway to ip_spaces_test.go

---------

Signed-off-by: Aritra Sen <sena@sena0MD6R.vmware.com>
Co-authored-by: Aritra Sen <sena@sena0MD6R.vmware.com>
(cherry picked from commit a38d62ea9ece0958f8931c63ab19481957dc1df3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/344)
<!-- Reviewable:end -->
