### PR TITLE
[x-port][VKCI-293] Add methods to allocate, release, update Ip Space Allocations (#345)

### DIFF
--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1464,32 +1464,31 @@ func (gm *GatewayManager) IsNSXTBackedGateway() bool {
 	return isNSXTBackedGateway
 }
 
+// IsUsingIpSpaces Returns true if the gateway is using Ip Spaces, returns false if the gateway is using Ip blocks
+// in case the code is unable to determine the required info, it will return false with an error.
 func (gm *GatewayManager) IsUsingIpSpaces() (bool, error) {
+	edgeGatewayName := gm.GatewayRef.Name
 	vdc := gm.Client.VDC
 	if vdc == nil {
-		return false, fmt.Errorf("nil VDC object in client")
-	}
-	edgeGatewayName, err := vdc.FindEdgeGatewayNameByNetwork(gm.NetworkName)
-	if err != nil {
-		return false, err
+		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. nil VDC object in client", edgeGatewayName)
 	}
 	edgeGateway, err := vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. error [%v]", edgeGatewayName, err)
 	}
 
 	edgeGatewayUplinks := edgeGateway.EdgeGateway.EdgeGatewayUplinks
 	if edgeGatewayUplinks != nil {
 		if len(edgeGatewayUplinks) != 1 {
-			return false, fmt.Errorf("found invalid number of uplinks for gateway `%s`, expecting 1", edgeGatewayName)
+			return false, fmt.Errorf("found invalid number of uplinks for gateway [%s], expecting 1", edgeGatewayName)
 		}
 	} else {
-		return false, fmt.Errorf("no uplinks were found for gateway `%s`, expecting 1", edgeGatewayName)
+		return false, fmt.Errorf("no uplinks were found for gateway [%s], expecting 1", edgeGatewayName)
 	}
 
 	result := edgeGatewayUplinks[0].UsingIpSpace
 	if result == nil {
-		return false, fmt.Errorf("unable to determine if gateway is using IP spaces or not")
+		return false, fmt.Errorf("unable to determine if gateway [%s] is using IP spaces or not", edgeGatewayName)
 	}
 	return *result, nil
 }
@@ -1951,7 +1950,7 @@ func (gm *GatewayManager) UpdateLoadBalancer(ctx context.Context, lbPoolName str
 	return vsSummary.VirtualIpAddress, nil
 }
 
-// FetchIpSpacesBackingGateway Fetch list of Ip Spaces (via Id) accessible to the gateway
+// FetchIpSpacesBackingGateway Fetch list of Ip Spaces (Id) accessible to the gateway
 // If gateway is not using Ip Spaces, error would be generated that will contain the underlying VCD 403 error.
 func (gm *GatewayManager) FetchIpSpacesBackingGateway(ctx context.Context) ([]string, error) {
 	ipSpaceService := gm.Client.APIClient.IpSpacesApi
@@ -1986,4 +1985,153 @@ func (gm *GatewayManager) FetchIpSpacesBackingGateway(ctx context.Context) ([]st
 	}
 
 	return ipSpaceIds, nil
+}
+
+// FilterIpSpacesByType Takes in a list of Ip Space Ids and returns a list of govcd.IpSpace pointers that match the
+// filter value of "type". Valid value for "type" = ["PUBLIC" (types.IpSpacePublic), "PRIVATE" (types.IpSpacePrivate)]
+func (gm *GatewayManager) FilterIpSpacesByType(ipSpaceIds []string, ipSpaceType string) ([]*govcd.IpSpace, error) {
+	if (ipSpaceType != types.IpSpacePublic) && (ipSpaceType != types.IpSpacePrivate) {
+		return nil, fmt.Errorf("invalid type [%s] specified, expecting value from [PUBLIC, PRIVATE]", ipSpaceType)
+	}
+	if ipSpaceIds == nil {
+		ipSpaceIds = make([]string, 0)
+	}
+
+	filteredIpSpaces := make([]*govcd.IpSpace, 0)
+	for _, ipSpaceId := range ipSpaceIds {
+		ipSpace, err := gm.Client.VCDClient.GetIpSpaceById(ipSpaceId)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch details of Ip Space with id [%s], error [%v]", ipSpaceId, err)
+		}
+		if ipSpace.IpSpace.Type == ipSpaceType {
+			filteredIpSpaces = append(filteredIpSpaces, ipSpace)
+		}
+	}
+
+	return filteredIpSpaces, nil
+}
+
+// AllocateIpFromIpSpace Allocates a floating IP from a given Ip Space
+// returns the allocation Id, and allocated Ip on success
+// Note : the return types are string because there is no way to convert
+// IpSpaceIpAllocationRequestResult (output of org.IpSpaceAllocateIp) into an IpSpaceIpAllocation object
+func (gm *GatewayManager) AllocateIpFromIpSpace(ipSpace *govcd.IpSpace) (string, string, error) {
+	if ipSpace == nil {
+		return "", "", fmt.Errorf("unable to allocate floating Ip from Ip Space [nil]")
+	}
+
+	org, err := gm.Client.VCDClient.GetOrgByName(gm.Client.ClusterOrgName)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to allocate floating Ip from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
+	}
+
+	val := 1
+	request := types.IpSpaceIpAllocationRequest{
+		Type:     types.IpSpaceIpAllocationTypeFloatingIp,
+		Quantity: &val,
+	}
+	result, err := org.IpSpaceAllocateIp(ipSpace.IpSpace.ID, &request)
+
+	if err != nil {
+		return "", "", fmt.Errorf("unable to allocate floating IP from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
+	}
+
+	if result == nil || len(result) != 1 {
+		return "", "", fmt.Errorf("unable to allocate exactly 1 floating Ip from Ip Space [%s]", ipSpace.IpSpace.Name)
+	}
+
+	return result[0].ID, result[0].Value, nil
+}
+
+// FindIpAllocationByIp Finds an IP allocation in the given Ip Space that matches the provided IP address
+// returns no error if no such allocation is found
+func (gm *GatewayManager) FindIpAllocationByIp(ipSpace *govcd.IpSpace, allocatedIp string) (*govcd.IpSpaceIpAllocation, error) {
+	if ipSpace == nil {
+		return nil, fmt.Errorf("unable to find allocation for floating Ip [%s] in Ip Space [nil]", allocatedIp)
+	}
+	queryParams := url.Values{}
+	queryParams.Set("filter", fmt.Sprintf("value==%s", allocatedIp))
+
+	allocations, err := ipSpace.GetAllIpSpaceAllocations(types.IpSpaceIpAllocationTypeFloatingIp, queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find allocation in Ip Space [%s], correspnding to Ip [%s]. error [%v]", ipSpace.IpSpace.Name, allocatedIp, err)
+	}
+
+	// If no allocations were made on the Ip Space with the specified Ip, it is valid to return no result with no error
+	// This use case is important for us, hence skipping GetIpSpaceAllocationByTypeAndValue
+	if allocations == nil || len(allocations) == 0 {
+		return nil, nil
+	}
+
+	if len(allocations) == 1 {
+		return allocations[0], nil
+	}
+
+	// Ideally we should never reach here, since VCD shouldn't make multiple allocations for the same IP
+	return nil, fmt.Errorf("found multiple allocations in Ip Space [%s] for Ip [%s]", ipSpace.IpSpace.Name, allocatedIp)
+}
+
+// FindIpAllocationByMarker We are adding info in the description of IpAllocation
+// to record that particular allocation was made by a CSE cluster. This method finds an
+// allocation corresponding to the previously stored description
+func (gm *GatewayManager) FindIpAllocationByMarker(ipSpace *govcd.IpSpace, marker string) (*govcd.IpSpaceIpAllocation, error) {
+	if ipSpace == nil {
+		return nil, fmt.Errorf("unable to find allocation for marker [%s] in Ip Space [nil]", marker)
+	}
+	queryParams := url.Values{}
+	queryParams.Set("filter", fmt.Sprintf("usageState==%s", types.IpSpaceIpAllocationUsedManual))
+
+	allocations, err := ipSpace.GetAllIpSpaceAllocations(types.IpSpaceIpAllocationTypeFloatingIp, queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find allocation in Ip Space [%s], correspnding to marker [%s]. error [%v]", ipSpace.IpSpace.Name, marker, err)
+	}
+
+	// If no allocations were made on the Ip Space, it is valid to return no result without error
+	if allocations == nil || len(allocations) == 0 {
+		return nil, nil
+	}
+
+	for _, allocation := range allocations {
+		if allocation.IpSpaceIpAllocation.Description == marker {
+			return allocation, nil
+		}
+	}
+
+	// If no allocation with the marker is found it is ok to return back with no result and no error
+	return nil, nil
+}
+
+// MarkIpAsUsed We are adding info in the description  of IpAllocation
+// to track that particular allocation was made by CSE cluster. This method updates
+// the state and description of an allocation to mark the cluster which owns the allocation.
+func (gm *GatewayManager) MarkIpAsUsed(ipSpaceAllocation *govcd.IpSpaceIpAllocation, marker string) (*govcd.IpSpaceIpAllocation, error) {
+	if ipSpaceAllocation == nil {
+		return nil, fmt.Errorf("unable to mark Ip Allocation [nil] as used, via marker [%s]", marker)
+	}
+	updateConfig := ipSpaceAllocation.IpSpaceIpAllocation
+	updateConfig.UsageState = types.IpSpaceIpAllocationUsedManual
+	updateConfig.Description = marker
+
+	return ipSpaceAllocation.Update(updateConfig)
+}
+
+// MarkIpAsUnused We are adding info in the description  of IpAllocation
+// to track that particular allocation was made by CSE cluster. This method updates
+// the state and description of an allocation to mark that the cluster no longer owns the allocation.
+func (gm *GatewayManager) MarkIpAsUnused(ipSpaceAllocation *govcd.IpSpaceIpAllocation) (*govcd.IpSpaceIpAllocation, error) {
+	if ipSpaceAllocation == nil {
+		return nil, fmt.Errorf("unable to mark IP allocation [nil] as unused")
+	}
+	updateConfig := ipSpaceAllocation.IpSpaceIpAllocation
+	updateConfig.UsageState = types.IpSpaceIpAllocationUnused
+	updateConfig.Description = ""
+
+	return ipSpaceAllocation.Update(updateConfig)
+}
+
+func (gm *GatewayManager) ReleaseIp(ipSpaceAllocation *govcd.IpSpaceIpAllocation) error {
+	if ipSpaceAllocation == nil {
+		return fmt.Errorf("unable to release Ip Allocation [nil]")
+	}
+	return ipSpaceAllocation.Delete()
 }

--- a/pkg/vcdsdk/ip_spaces_test.go
+++ b/pkg/vcdsdk/ip_spaces_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
@@ -86,15 +87,112 @@ func TestFetchIpSpacesBackingGateway(t *testing.T) {
 	assert.NoErrorf(t, err, "Unable to create Gateway Manager for network %s", testData.OrgvdcNetworkIpSpace)
 
 	fmt.Println("Calling FetchIpSpacesBackingGateway for gateway using Ip Spaces")
-	result, err := gm.FetchIpSpacesBackingGateway(ctx)
+	ipSpaceIds, err := gm.FetchIpSpacesBackingGateway(ctx)
 	assert.NoErrorf(t, err, "Error calling method FetchIpSpacesBackingGateway for netowrk %s", testData.OrgvdcNetworkIpSpace)
-	assert.Greater(t, len(result), 0)
+	assert.Greater(t, len(ipSpaceIds), 0)
+
+	fmt.Println("Calling FilterIpSpacesByType for gateway using Ip Spaces")
+	ipSpaces, err := gm.FilterIpSpacesByType(ipSpaceIds, "PUBLIC")
+	assert.NoErrorf(t, err, "Error calling method FilterIpSpacesByType for Ids %s", ipSpaceIds)
+	assert.Equal(t, 1, len(ipSpaces))
 
 	gm2, err := NewGatewayManager(ctx, vcdClient, testData.OrgvdcNetworkNoIpSpace, "", testData.Orgvdc)
 	assert.NoErrorf(t, err, "Unable to create Gateway Manager for network %s", testData.OrgvdcNetworkNoIpSpace)
 
 	fmt.Println("Calling FetchIpSpacesBackingGateway for gateway using Ip blocks")
-	result, err = gm2.FetchIpSpacesBackingGateway(ctx)
+	_, err = gm2.FetchIpSpacesBackingGateway(ctx)
 	assert.Error(t, err, "Expected error calling method IsUsingIpSpaces for network %s", testData.OrgvdcNetworkNoIpSpace)
 	assert.True(t, strings.Contains(err.Error(), "403 Forbidden"), "Expected '403 forbidden' message in error found %s", err.Error())
+}
+
+func TestIpSpaceOperations(t *testing.T) {
+	vcdConfig, err := getTestVCDConfig()
+	assert.NoError(t, err, "There should be no error opening and parsing vcd info file contents.")
+
+	testDataFile := filepath.Join(gitRoot, "testdata/ip_space_test.yaml")
+	testDataFileContent, err := os.ReadFile(testDataFile)
+	assert.NoError(t, err, "There should be no error reading the ip space test data file contents.")
+
+	var testData ipSpaceDetails
+	err = yaml.Unmarshal(testDataFileContent, &testData)
+	assert.NoError(t, err, "There should be no error parsing ip space test data file content.")
+
+	vcdClient, err := getTestVCDClient(vcdConfig, map[string]interface{}{
+		"user":         testData.Username,
+		"userOrg":      testData.UserOrg,
+		"refreshToken": testData.RefreshToken,
+		"org":          testData.UserOrg,
+		"vdc":          testData.Orgvdc,
+		"getVdcClient": true,
+	})
+	assert.NoError(t, err, "Unable to get VCD client")
+	require.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	ctx := context.Background()
+
+	gm, err := NewGatewayManager(ctx, vcdClient, testData.OrgvdcNetworkIpSpace, "", testData.Orgvdc)
+	assert.NoErrorf(t, err, "Unable to create Gateway Manager for network %s", testData.OrgvdcNetworkIpSpace)
+
+	fmt.Println("Calling FetchIpSpacesBackingGateway for gateway using Ip Spaces")
+	ipSpaceIds, err := gm.FetchIpSpacesBackingGateway(ctx)
+	assert.NoErrorf(t, err, "Error calling method FetchIpSpacesBackingGateway for netowrk %s", testData.OrgvdcNetworkIpSpace)
+	assert.Greater(t, len(ipSpaceIds), 0)
+
+	fmt.Println("Calling FilterIpSpacesByType for gateway using Ip Spaces")
+	ipSpaces, err := gm.FilterIpSpacesByType(ipSpaceIds, "PUBLIC")
+	assert.NoErrorf(t, err, "Error calling method FilterIpSpacesByType for Ids %s", ipSpaceIds)
+	assert.Equal(t, 1, len(ipSpaces))
+
+	ipSpace := ipSpaces[0]
+
+	fmt.Println("Calling AllocateIpFromIpSpace for gateway using Ip Spaces")
+	allocationId, allocatedIp, err := gm.AllocateIpFromIpSpace(ipSpace)
+	assert.NoError(t, err, "Error calling method AllocateIpFromIpSpace for IpSpace [%s]", ipSpace.IpSpace.Name)
+	assert.NotNil(t, allocationId, "Expected non nil Allocation Id")
+	assert.NotNil(t, allocatedIp, "Expected non nil Allocated Ip")
+
+	fmt.Println("Calling FindIpAllocationByIp for gateway using Ip Spaces")
+	retrievedIpSpaceAllocation, err := gm.FindIpAllocationByIp(ipSpace, allocatedIp)
+	assert.NoError(t, err, "Error calling method FindIpAllocationByIp for IpSpace [%s], Ip [%s]", ipSpace.IpSpace.Name, allocatedIp)
+	assert.NotNil(t, retrievedIpSpaceAllocation)
+	assert.Equal(t, allocationId, retrievedIpSpaceAllocation.IpSpaceIpAllocation.ID, "")
+	assert.Equal(t, allocatedIp, retrievedIpSpaceAllocation.IpSpaceIpAllocation.Value, "")
+
+	fmt.Println("Calling FindIpAllocationByIp with invalid IP for gateway using Ip Spaces")
+	invalidIp := "0.0.0.0"
+	retrievedIpSpaceAllocation2, err := gm.FindIpAllocationByIp(ipSpace, invalidIp)
+	assert.NoError(t, err, "Error calling method FindIpAllocationByIp for IpSpace [%s], Ip [%s]", ipSpace.IpSpace.Name, invalidIp)
+	assert.Nil(t, retrievedIpSpaceAllocation2)
+
+	dummyMarker := "Dummy Marker"
+	fmt.Println("Calling MarkIpAsUsed for gateway using Ip Spaces")
+	updatedIpSpaceAllocation, err := gm.MarkIpAsUsed(retrievedIpSpaceAllocation, dummyMarker)
+	assert.NoError(t, err, "Error calling method MarkIpAsUsed for Allocation [%s]", retrievedIpSpaceAllocation.IpSpaceIpAllocation.ID)
+	assert.NotNil(t, updatedIpSpaceAllocation)
+	assert.Equal(t, types.IpSpaceIpAllocationUsedManual, updatedIpSpaceAllocation.IpSpaceIpAllocation.UsageState)
+	assert.Equal(t, dummyMarker, updatedIpSpaceAllocation.IpSpaceIpAllocation.Description)
+
+	fmt.Println("Calling FindIpAllocationByMarker for gateway using Ip Spaces")
+	retrievedIpSpaceAllocation3, err := gm.FindIpAllocationByMarker(ipSpace, dummyMarker)
+	assert.NoError(t, err, "Error calling method FindIpAllocationByMarker for Ip Space [%s] with marker [%s]", ipSpace.IpSpace.Name, dummyMarker)
+	assert.NotNil(t, retrievedIpSpaceAllocation3)
+	assert.Equal(t, retrievedIpSpaceAllocation.IpSpaceIpAllocation.ID, retrievedIpSpaceAllocation3.IpSpaceIpAllocation.ID, "")
+	assert.Equal(t, retrievedIpSpaceAllocation.IpSpaceIpAllocation.Value, retrievedIpSpaceAllocation3.IpSpaceIpAllocation.Value, "")
+
+	fmt.Println("Calling FindIpAllocationByMarker with invalid marker for gateway using Ip Spaces")
+	invalidMarker := "invalid"
+	retrievedIpSpaceAllocation4, err := gm.FindIpAllocationByMarker(ipSpace, invalidMarker)
+	assert.NoError(t, err, "Error calling method FindIpAllocationByMarker for Ip Space [%s] with marker [%s]", retrievedIpSpaceAllocation.IpSpaceIpAllocation.ID, invalidMarker)
+	assert.Nil(t, retrievedIpSpaceAllocation4)
+
+	fmt.Println("Calling MarkIpAsUnused for gateway using Ip Spaces")
+	updatedIpSpaceAllocation, err = gm.MarkIpAsUnused(retrievedIpSpaceAllocation3)
+	assert.NoError(t, err, "Error calling method MarkIpAsUnused for Allocation [%s]", retrievedIpSpaceAllocation3.IpSpaceIpAllocation.ID)
+	assert.NotNil(t, updatedIpSpaceAllocation)
+	assert.Equal(t, types.IpSpaceIpAllocationUnused, updatedIpSpaceAllocation.IpSpaceIpAllocation.UsageState)
+	assert.Equal(t, "", updatedIpSpaceAllocation.IpSpaceIpAllocation.Description)
+
+	fmt.Println("Calling ReleaseIp for gateway using Ip Spaces")
+	err = gm.ReleaseIp(updatedIpSpaceAllocation)
+	assert.NoError(t, err, "Error calling method ReleaseIp for Allocation [%s]", updatedIpSpaceAllocation.IpSpaceIpAllocation.ID)
 }


### PR DESCRIPTION
Added methods :
FilterIpSpacesByType
AllocateIpFromIpSpace
FindIpAllocationByIp
FindIpAllocationByMarker
MarkIpAsUsed
MarkIpAsUnused
ReleaseIp

Testing Done:
Added the following test in ip_spaces_test.go to test all the above mentioned methods TestIpSpaceOperations
---------

Signed-off-by: Aritra Sen <sena@sena0MD6R.vmware.com>
Co-authored-by: Aritra Sen <sena@sena0MD6R.vmware.com>
(cherry picked from commit 74fa1096927c1e708efd2b4560debd49802aaa57)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/346)
<!-- Reviewable:end -->
