### PR TITLE
[VKCI-294] Reserve Ip from Ip Space during Load Balancer creation

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -407,7 +407,7 @@ func (lb *LBManager) getVirtualServicePrefix(_ context.Context, service *v1.Serv
 // cluster Id, which allows CPI to uniquely mark an IP Allocation (from an Ip Space) being owned
 // by a particular service running on a specific cluster under a specific namespace
 func (lb *LBManager) getLoadBalancerIpClaimMarker(_ context.Context, service *v1.Service) string {
-	return fmt.Sprintf("cluster-%s-namespace-%s-service-%s", lb.clusterID, service.Namespace, service.Name)
+	return fmt.Sprintf("cluster-%s-namespace-%s-service-%s", lb.getTrimmedClusterID(), service.Namespace, service.Name)
 }
 
 // GetLoadBalancerName returns the name of the load balancer. Implementations must treat the

--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -2189,11 +2189,13 @@ func (gm *GatewayManager) reserveIpForLoadBalancer(ctx context.Context, claimMar
 
 		ipSpaceAllocation, err := gm.FindIpAllocationByIp(ipSpace, allocatedIp)
 		if err != nil || ipSpaceAllocation == nil {
+			klog.Infof("leaked IP [%s] from Ip Space [%s]", allocatedIp, ipSpace.IpSpace.Name)
 			return "", fmt.Errorf("unable to resrve IP from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
 		}
 
 		_, err = gm.MarkIpAsUsed(ipSpaceAllocation, claimMarker)
 		if err != nil {
+			klog.Infof("leaked IP [%s] from Ip Space [%s]", allocatedIp, ipSpace.IpSpace.Name)
 			return "", fmt.Errorf("unable to resrve IP from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
 		}
 		return ipSpaceAllocation.IpSpaceIpAllocation.Value, nil


### PR DESCRIPTION
Added methods:
reserveIpForLoadBalancer in gateway.go
getLoadBalancerIpClaimMarker in loadbalancer.go

Updated methods:
createLoadBalancer in loadbalancer.go
CreateLoadBalancer in gateway.go

to enable reserving Ip for load balancers from Ip Spaces if the gateway supports it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/347)
<!-- Reviewable:end -->
