### PR TITLE
[x-port][VKCI-294] Reserve Ip from Ip Space during Load Balancer creation (#347)

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -403,6 +403,13 @@ func (lb *LBManager) getVirtualServicePrefix(_ context.Context, service *v1.Serv
 	return fmt.Sprintf("ingress-vs-%s-%s", service.Name, lb.getTrimmedClusterID())
 }
 
+// getLoadBalancerIpClaimMarker returns a string comprising the service namespace, service name and
+// cluster Id, which allows CPI to uniquely mark an IP Allocation (from an Ip Space) being owned
+// by a particular service running on a specific cluster under a specific namespace
+func (lb *LBManager) getLoadBalancerIpClaimMarker(_ context.Context, service *v1.Service) string {
+	return fmt.Sprintf("cluster-%s-namespace-%s-service-%s", lb.getTrimmedClusterID(), service.Namespace, service.Name)
+}
+
 // GetLoadBalancerName returns the name of the load balancer. Implementations must treat the
 // *v1.Service parameter as read-only and not modify it.
 func (lb *LBManager) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
@@ -521,9 +528,11 @@ func getUserSpecifiedLoadBalancerIP(service *v1.Service) string {
 func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service,
 	nodeIPs []string) (*v1.LoadBalancerStatus, error) {
 
+	lbIpClaimMarker := lb.getLoadBalancerIpClaimMarker(ctx, service)
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
 	virtualServiceNamePrefix := lb.getVirtualServicePrefix(ctx, service)
 	lbStatus, portNameToIPMap, err := lb.getLoadBalancer(ctx, service)
+
 	rdeManager := vcdsdk.NewRDEManager(lb.vcdClient, lb.clusterID, release.CloudControllerManagerName, release.Version)
 	cpiRdeManager := cpisdk.NewCPIRDEManager(rdeManager)
 	if err != nil {
@@ -675,7 +684,7 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 	klog.Infof("Creating loadbalancer for ports [%#v]\n", portDetailsList)
 	// Create using VCD API
 	resourcesAllocated := &util.AllocatedResourcesMap{}
-	lbIP, err := gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, nodeIPs, portDetailsList,
+	lbIP, err := gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, lbIpClaimMarker, nodeIPs, portDetailsList,
 		lb.OneArm, lb.EnableVirtualServiceSharedIP, portNameToIPMap, userSpecifiedLBIP, resourcesAllocated)
 	if rdeErr := lb.addLBResourcesToRDE(ctx, resourcesAllocated, lbIP); rdeErr != nil {
 		return nil, fmt.Errorf("unable to add load balancer pool resources to RDE [%s]: [%v]", lb.clusterID, err)

--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1530,7 +1530,8 @@ func (gm *GatewayManager) GetLoadBalancerPoolMemberIPs(ctx context.Context, lbPo
 	return memberIPs, nil
 }
 
-func (gm *GatewayManager) CreateLoadBalancer(ctx context.Context, virtualServiceNamePrefix string, lbPoolNamePrefix string,
+func (gm *GatewayManager) CreateLoadBalancer(
+	ctx context.Context, virtualServiceNamePrefix string, lbPoolNamePrefix string, lbIpClaimMarker string,
 	ips []string, portDetailsList []PortDetails, oneArm *OneArm, enableVirtualServiceSharedIP bool,
 	portNameToIP map[string]string, providedIP string, resourcesAllocated *util.AllocatedResourcesMap) (string, error) {
 	if len(portDetailsList) == 0 {
@@ -1614,10 +1615,23 @@ func (gm *GatewayManager) CreateLoadBalancer(ctx context.Context, virtualService
 	}
 
 	if externalIP == "" {
-		externalIP, err = gm.GetUnusedExternalIPAddress(ctx, gm.IPAMSubnet)
+		isGatewayUsingIpSpaces, err := gm.IsUsingIpSpaces()
 		if err != nil {
-			return "", fmt.Errorf("unable to get unused IP address from subnet [%s]: [%v]",
-				gm.IPAMSubnet, err)
+			return "", fmt.Errorf("unable to create load balancer. err [%v]", err)
+		}
+		if isGatewayUsingIpSpaces {
+			klog.Infof("Determined gateway [%s] is using IP spaces, using IP space specific logic to reserve an IP", gm.GatewayRef.Name)
+			externalIP, err = gm.reserveIpForLoadBalancer(ctx, lbIpClaimMarker)
+			if err != nil {
+				return "", fmt.Errorf("unable to reservce IP address for load balancer. error [%v]", err)
+			}
+		} else {
+			klog.Infof("Determined gateway [%s] is not using IP spaces, using legacy IPAM solution to find a free IP", gm.GatewayRef.Name)
+			externalIP, err = gm.GetUnusedExternalIPAddress(ctx, gm.IPAMSubnet)
+			if err != nil {
+				return "", fmt.Errorf("unable to get unused IP address from subnet [%s]: [%v]",
+					gm.IPAMSubnet, err)
+			}
 		}
 	}
 	klog.Infof("Using VIP [%s] for virtual service\n", externalIP)
@@ -2134,4 +2148,64 @@ func (gm *GatewayManager) ReleaseIp(ipSpaceAllocation *govcd.IpSpaceIpAllocation
 		return fmt.Errorf("unable to release Ip Allocation [nil]")
 	}
 	return ipSpaceAllocation.Delete()
+}
+
+// reserveIpForLoadBalancer will scan through all Ip Spaces available to the gateway for an existing allocation
+// (description of allocation will contain cluster id, service name and namespace). If such an allocation can't be
+// retrieved, a new Ip Allocation will be attempted against all Ip Spaces, sequentially. The first Ip Space that allows
+// the reservation to go through, will conclude the process. The allocation will be moved to USED_MANUAL state and its
+// description will be updated to mark a claim. The allocated Ip will be returned. If all Ip Spaces reject the
+// allocation request, this method will return an error
+func (gm *GatewayManager) reserveIpForLoadBalancer(ctx context.Context, claimMarker string) (string, error) {
+	ipSpaceIds, err := gm.FetchIpSpacesBackingGateway(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to reserve IP from Ip Space. error [%v]", err)
+	}
+
+	publicIpSpaces, err := gm.FilterIpSpacesByType(ipSpaceIds, types.IpSpacePublic)
+	if err != nil {
+		return "", fmt.Errorf("unable to reserve IP from Ip Space. error [%v]", err)
+	}
+
+	for _, ipSpace := range publicIpSpaces {
+		ipSpaceAllocation, err := gm.FindIpAllocationByMarker(ipSpace, claimMarker)
+		if err != nil {
+			return "", fmt.Errorf("unable to reserve IP from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
+		}
+		// Found an existing allocation for this particular service
+		if ipSpaceAllocation != nil {
+			return ipSpaceAllocation.IpSpaceIpAllocation.Value, nil
+		}
+	}
+
+	// if we haven't found any allocation yet on all accessible Ip Spaces, we need to create a new allocation
+	// NOTE: The allocation mechanism needs two calls to VCD and should be treated like a critical section
+	// Under all circumstances, two instances of CPI will never try to create a lb for a service simultaneously, so we should be good.
+	for _, ipSpace := range publicIpSpaces {
+		_, allocatedIp, err := gm.AllocateIpFromIpSpace(ipSpace)
+		if err != nil {
+			// don't give up yet, allocation can fail because Ip Space has no free Ip, try the next Ip Space
+			klog.Infof("unable to reserve IP from Ip Space [%s]. error [%v]. will try next ip Space.", ipSpace.IpSpace.Name, err)
+			continue
+		}
+
+		// We were able to make an allocation, so we should be able to retrieve it
+		// if retrieval fails, we should fail and not try to allocate another IP from the next
+		// IP space
+		ipSpaceAllocation, err := gm.FindIpAllocationByIp(ipSpace, allocatedIp)
+		if err != nil || ipSpaceAllocation == nil {
+			klog.Infof("leaked IP [%s] from Ip Space [%s]. Unable to retrieve allocated IP.", allocatedIp, ipSpace.IpSpace.Name)
+			return "", fmt.Errorf("unable to reserve IP from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
+		}
+
+		_, err = gm.MarkIpAsUsed(ipSpaceAllocation, claimMarker)
+		if err != nil {
+			klog.Infof("leaked IP [%s] from Ip Space [%s]. Unable to mark allocated IP as used.", allocatedIp, ipSpace.IpSpace.Name)
+			return "", fmt.Errorf("unable to reserve IP from Ip Space [%s]. error [%v]", ipSpace.IpSpace.Name, err)
+		}
+		return ipSpaceAllocation.IpSpaceIpAllocation.Value, nil
+	}
+
+	// Was unable to reserve an Ip on any of the available Ip Spaces
+	return "", fmt.Errorf("unable to reserve Ip from any available Ip spaces")
 }


### PR DESCRIPTION
Added methods:
reserveIpForLoadBalancer in gateway.go
getLoadBalancerIpClaimMarker in loadbalancer.go

Updated methods:
createLoadBalancer in loadbalancer.go
CreateLoadBalancer in gateway.go

to enable reserving Ip for load balancers from Ip Spaces if the gateway supports it. ---------

Signed-off-by: Aritra Sen <sena@sena0MD6R.vmware.com>
Co-authored-by: Aritra Sen <sena@sena0MD6R.vmware.com>
(cherry picked from commit 4d16495e17bec903dc46b752347fd71bd4723c55)