### PR TITLE
[x-port][VKCI-295] Release IP on load balancer Deletion (#349)

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -418,6 +418,7 @@ func (lb *LBManager) GetLoadBalancerName(ctx context.Context, clusterName string
 
 func (lb *LBManager) deleteLoadBalancer(ctx context.Context, service *v1.Service) error {
 
+	lbIpClaimMarker := lb.getLoadBalancerIpClaimMarker(ctx, service)
 	virtualServiceName := lb.getVirtualServicePrefix(ctx, service)
 	lbPoolNamePrefix := lb.getLBPoolNamePrefix(ctx, service)
 	klog.Infof("Deleting virtual service [%s] and lb pool [%s]", virtualServiceName, lbPoolNamePrefix)
@@ -439,7 +440,7 @@ func (lb *LBManager) deleteLoadBalancer(ctx context.Context, service *v1.Service
 		return fmt.Errorf("error while creating GatewayManager: [%v]", err)
 	}
 	resourcesDeallocated := &util.AllocatedResourcesMap{}
-	vip, err := gm.DeleteLoadBalancer(ctx, virtualServiceName, lbPoolNamePrefix, portDetailsList, lb.OneArm, resourcesDeallocated)
+	vip, err := gm.DeleteLoadBalancer(ctx, virtualServiceName, lbPoolNamePrefix, lbIpClaimMarker, portDetailsList, lb.OneArm, resourcesDeallocated)
 	if rdeErr := lb.removeLBResourcesFromRDE(ctx, resourcesDeallocated); rdeErr != nil {
 		klog.Errorf("failed to remove loadbalancer resources from RDE [%s]: [%v]", lb.clusterID, rdeErr)
 		return fmt.Errorf("failed to remove loadbalancer resources from RDE [%s]: [%v]", lb.clusterID, rdeErr)

--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1621,7 +1621,7 @@ func (gm *GatewayManager) CreateLoadBalancer(
 		}
 		if isGatewayUsingIpSpaces {
 			klog.Infof("Determined gateway [%s] is using IP spaces, using IP space specific logic to reserve an IP", gm.GatewayRef.Name)
-			externalIP, err = gm.reserveIpForLoadBalancer(ctx, lbIpClaimMarker)
+			externalIP, err = gm.ReserveIpForLoadBalancer(ctx, lbIpClaimMarker)
 			if err != nil {
 				return "", fmt.Errorf("unable to reservce IP address for load balancer. error [%v]", err)
 			}
@@ -1776,8 +1776,9 @@ func (gm *GatewayManager) CreateLoadBalancer(
 	return externalIP, nil
 }
 
-func (gm *GatewayManager) DeleteLoadBalancer(ctx context.Context, virtualServiceNamePrefix string,
-	lbPoolNamePrefix string, portDetailsList []PortDetails, oneArm *OneArm, resourcesDeallocated *util.AllocatedResourcesMap) (string, error) {
+func (gm *GatewayManager) DeleteLoadBalancer(
+	ctx context.Context, virtualServiceNamePrefix string, lbPoolNamePrefix string, lbIpClaimMarker string,
+	portDetailsList []PortDetails, oneArm *OneArm, resourcesDeallocated *util.AllocatedResourcesMap) (string, error) {
 
 	if gm == nil {
 		return "", fmt.Errorf("GatewayManager cannot be nil")
@@ -1805,6 +1806,7 @@ func (gm *GatewayManager) DeleteLoadBalancer(ctx context.Context, virtualService
 		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portDetails.PortSuffix)
 
 		// get external IP
+		// it is weird that we are computing the same external Id multiple times in the loop
 		dnatRuleName := ""
 		if oneArm != nil {
 			dnatRuleName = GetDNATRuleName(virtualServiceName)
@@ -1871,6 +1873,19 @@ func (gm *GatewayManager) DeleteLoadBalancer(ctx context.Context, virtualService
 			})
 		}
 	}
+
+	isGatewayUsingIpSpaces, err := gm.IsUsingIpSpaces()
+	if err != nil {
+		return "", fmt.Errorf("unable to release IP [%s] used by load balancer. err [%v]", rdeVIP, err)
+	}
+	if isGatewayUsingIpSpaces {
+		klog.Infof("Determined gateway [%s] is using IP spaces, using IP space specific logic to release IP [%s]", gm.GatewayRef.Name, rdeVIP)
+		err = gm.ReleaseIpFromLoadBalancer(ctx, rdeVIP, lbIpClaimMarker)
+		if err != nil {
+			return "", fmt.Errorf("unable to release IP address [%s] from load balancer. error [%v]", rdeVIP, err)
+		}
+	}
+	// if gateway is using IP blocks, no need to explicitly release the IP
 
 	return rdeVIP, nil
 }
@@ -2150,13 +2165,13 @@ func (gm *GatewayManager) ReleaseIp(ipSpaceAllocation *govcd.IpSpaceIpAllocation
 	return ipSpaceAllocation.Delete()
 }
 
-// reserveIpForLoadBalancer will scan through all Ip Spaces available to the gateway for an existing allocation
+// ReserveIpForLoadBalancer will scan through all Ip Spaces available to the gateway for an existing allocation
 // (description of allocation will contain cluster id, service name and namespace). If such an allocation can't be
 // retrieved, a new Ip Allocation will be attempted against all Ip Spaces, sequentially. The first Ip Space that allows
 // the reservation to go through, will conclude the process. The allocation will be moved to USED_MANUAL state and its
 // description will be updated to mark a claim. The allocated Ip will be returned. If all Ip Spaces reject the
 // allocation request, this method will return an error
-func (gm *GatewayManager) reserveIpForLoadBalancer(ctx context.Context, claimMarker string) (string, error) {
+func (gm *GatewayManager) ReserveIpForLoadBalancer(ctx context.Context, claimMarker string) (string, error) {
 	ipSpaceIds, err := gm.FetchIpSpacesBackingGateway(ctx)
 	if err != nil {
 		return "", fmt.Errorf("unable to reserve IP from Ip Space. error [%v]", err)
@@ -2208,4 +2223,52 @@ func (gm *GatewayManager) reserveIpForLoadBalancer(ctx context.Context, claimMar
 
 	// Was unable to reserve an Ip on any of the available Ip Spaces
 	return "", fmt.Errorf("unable to reserve Ip from any available Ip spaces")
+}
+
+// ReleaseIpFromLoadBalancer will scan through all Ip Spaces available to the gateway for an existing allocation
+// (description of allocation will contain cluster id, service name and namespace). If such an allocation can't be
+// retrieved, the method will return without raising any error. It should be assumed that the allocation was removed in
+// a previous attempt. If an allocation is found, it will be deleted, thereby releasing the IP from the load balancer as well
+// as tenant context. It should be noted that if the cluster was created with user provider external IP, then the allocation
+// will not be present on any of the IP Spaces, and hence we will not try to release the IP.
+func (gm *GatewayManager) ReleaseIpFromLoadBalancer(ctx context.Context, rdeVIP string, claimMarker string) error {
+	ipSpaceIds, err := gm.FetchIpSpacesBackingGateway(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to release IP [%s] from load balancer. error [%v]", rdeVIP, err)
+	}
+
+	publicIpSpaces, err := gm.FilterIpSpacesByType(ipSpaceIds, types.IpSpacePublic)
+	if err != nil {
+		return fmt.Errorf("unable to release IP [%s] from load balancer. error [%v]", rdeVIP, err)
+	}
+
+	for _, ipSpace := range publicIpSpaces {
+		ipSpaceAllocation, err := gm.FindIpAllocationByMarker(ipSpace, claimMarker)
+		if err != nil {
+			return fmt.Errorf("unable to release IP [%s] from Ip Space [%s]. error [%v]", rdeVIP, ipSpace.IpSpace.Name, err)
+		}
+		// In case an allocation is not found on this Ip Space, we will have ipSpaceAllocation = nil, err = nil
+		if ipSpaceAllocation != nil {
+			// Found an existing allocation for this particular service
+			allocatedIp := ipSpaceAllocation.IpSpaceIpAllocation.Value
+			if allocatedIp != rdeVIP {
+				return fmt.Errorf("RDE VIP [%s] doesn't match allocated IP [%s] in IP Space [%s] for marker [%s]", rdeVIP, allocatedIp, ipSpace.IpSpace.Name, claimMarker)
+			}
+			updatedIpSpaceAllocation, err := gm.MarkIpAsUnused(ipSpaceAllocation)
+			if err != nil {
+				return fmt.Errorf("unable to mark IP [%s] from IP Space [%s] as unused. error [%v]", allocatedIp, ipSpace.IpSpace.Name, err)
+			}
+			err = gm.ReleaseIp(updatedIpSpaceAllocation)
+			if err != nil {
+				return fmt.Errorf("unable to release IP [%s] from IP Space [%s]. error [%v]", allocatedIp, ipSpace.IpSpace.Name, err)
+			}
+			// No need to process any more IP spaces, it is safe to return from this function
+			return nil
+		}
+	}
+
+	// If we have reached here, it means, we couldn't locate an allocation corresponding to the marker
+	// Either the IP was released in a previous attempt, or the external IP was assigned manually by
+	// the user. In either case, we have nothing to do here and we should safely return.
+	return nil
 }

--- a/pkg/vcdsdk/gateway_system_test.go
+++ b/pkg/vcdsdk/gateway_system_test.go
@@ -548,7 +548,7 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 		EndIP:   "192.168.8.100",
 	}
 	freeIP, err = gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
-		lbPoolNamePrefix, []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, false, nil, "", &util.AllocatedResourcesMap{})
+		lbPoolNamePrefix, "", []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, false, nil, "", &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be created")
 	assert.NotEmpty(t, freeIP, "There should be a non-empty IP returned")
 
@@ -567,7 +567,7 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 	assert.Equal(t, freeIP, freeIPObtained, "The IPs should match")
 
 	freeIP, err = gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
-		lbPoolNamePrefix, []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, false, nil, "", &util.AllocatedResourcesMap{})
+		lbPoolNamePrefix, "", []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, false, nil, "", &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be created even on second attempt")
 	assert.NotEmpty(t, freeIP, "There should be a non-empty IP returned")
 
@@ -597,7 +597,7 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 	_, err = gm.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-https", virtualServiceNamePrefix+"-https", updatedIps, "", updatedInternalPort, updatedExternalPortHttps, nil, false, "HTTPS", &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "HTTPS Load Balancer should be updated")
 
-	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm, &util.AllocatedResourcesMap{})
+	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, "", portDetailsList, oneArm, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be deleted")
 
 	freeIPObtained, _, err = gm.GetLoadBalancer(ctx, virtualServiceNameHttp, lbPoolNameHttp, oneArm)
@@ -608,7 +608,7 @@ func TestLoadBalancerCRUDE(t *testing.T) {
 	assert.NoError(t, err, "Load Balancer should not be found")
 	assert.Empty(t, freeIPObtained, "The VIP should not be found")
 
-	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm, &util.AllocatedResourcesMap{})
+	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, "", portDetailsList, oneArm, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Repeated deletion of Load Balancer should not fail")
 
 	_, err = gm.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, "", updatedInternalPort, 80, nil, false, "HTTP", &util.AllocatedResourcesMap{})
@@ -675,7 +675,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmDisabled_CRUDE(t *testing.T) {
 
 	var oneArm *OneArm
 	freeIP, err = gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
-		lbPoolNamePrefix, []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
+		lbPoolNamePrefix, "", []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be created")
 	assert.NotEmpty(t, freeIP, "There should be a non-empty IP returned")
 	assert.Equal(t, freeIP, testConfig.FreeLoadBalancerIP, "the provided external IP address should be the same as the load balancer IP address.")
@@ -695,7 +695,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmDisabled_CRUDE(t *testing.T) {
 	assert.Equal(t, freeIP, freeIPObtained, "The IPs should match")
 
 	freeIP, err = gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
-		lbPoolNamePrefix, []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
+		lbPoolNamePrefix, "", []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be created even on second attempt")
 	assert.NotEmpty(t, freeIP, "There should be a non-empty IP returned")
 	assert.Equal(t, freeIP, testConfig.FreeLoadBalancerIP, "the provided external IP address should be the same as the load balancer IP address.")
@@ -734,7 +734,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmDisabled_CRUDE(t *testing.T) {
 	assert.NoError(t, err, "HTTP Load Balancer should be updated")
 	assert.Equal(t, lbIP, newLBIP, "updated external IP address should match the value specified")
 
-	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm, &util.AllocatedResourcesMap{})
+	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, "", portDetailsList, oneArm, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be deleted")
 
 	freeIPObtained, _, err = gm.GetLoadBalancer(ctx, virtualServiceNameHttp, lbPoolNameHttp, oneArm)
@@ -745,7 +745,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmDisabled_CRUDE(t *testing.T) {
 	assert.NoError(t, err, "Load Balancer should not be found")
 	assert.Empty(t, freeIPObtained, "The VIP should not be found")
 
-	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm, &util.AllocatedResourcesMap{})
+	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, "", portDetailsList, oneArm, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Repeated deletion of Load Balancer should not fail")
 
 	_, err = gm.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, testConfig.FreeLoadBalancerIP, updatedInternalPort, 80, nil, true, "HTTP", &util.AllocatedResourcesMap{})
@@ -816,7 +816,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmEnabled_CRUDE(t *testing.T) {
 	}
 
 	freeIP, err = gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
-		lbPoolNamePrefix, []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
+		lbPoolNamePrefix, "", []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be created")
 	assert.NotEmpty(t, freeIP, "There should be a non-empty IP returned")
 	assert.Equal(t, freeIP, testConfig.FreeLoadBalancerIP, "the provided external IP address should be the same as the load balancer IP address.")
@@ -836,7 +836,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmEnabled_CRUDE(t *testing.T) {
 	assert.Equal(t, freeIP, freeIPObtained, "The IPs should match")
 
 	freeIP, err = gm.CreateLoadBalancer(ctx, virtualServiceNamePrefix,
-		lbPoolNamePrefix, []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
+		lbPoolNamePrefix, "", []string{"1.2.3.4", "1.2.3.5"}, portDetailsList, oneArm, true, nil, testConfig.FreeLoadBalancerIP, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be created even on second attempt")
 	assert.NotEmpty(t, freeIP, "There should be a non-empty IP returned")
 
@@ -872,7 +872,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmEnabled_CRUDE(t *testing.T) {
 	assert.NoError(t, err, "HTTP Load Balancer should be updated")
 	assert.Equal(t, newLBIP, lbIP, "The external IP for the load balancer should be updated")
 
-	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm, &util.AllocatedResourcesMap{})
+	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, "", portDetailsList, oneArm, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Load Balancer should be deleted")
 
 	freeIPObtained, _, err = gm.GetLoadBalancer(ctx, virtualServiceNameHttp, lbPoolNameHttp, oneArm)
@@ -883,7 +883,7 @@ func TestLoadBalancer_ExplicitLBIP_OneArmEnabled_CRUDE(t *testing.T) {
 	assert.NoError(t, err, "Load Balancer should not be found")
 	assert.Empty(t, freeIPObtained, "The VIP should not be found")
 
-	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, portDetailsList, oneArm, &util.AllocatedResourcesMap{})
+	_, err = gm.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix, "", portDetailsList, oneArm, &util.AllocatedResourcesMap{})
 	assert.NoError(t, err, "Repeated deletion of Load Balancer should not fail")
 
 	_, err = gm.UpdateLoadBalancer(ctx, lbPoolNamePrefix+"-http", virtualServiceNamePrefix+"-http", updatedIps, testConfig.FreeLoadBalancerIP, updatedInternalPort, 80, oneArm, true, "HTTP", &util.AllocatedResourcesMap{})


### PR DESCRIPTION
Added method:
ReleaseIpFromLoadBalancer in gateway.go

Updated method:
DeleteLoadBalancer in gateway.go

Testing Done:
Add testcase TestIpAllocationAndReleaseToLoadBalancer to ip_spaces_test.go Fixed broken tests in gateway_system_test.go

---------

Signed-off-by: Aritra Sen <sena@sena0MD6R.vmware.com>
Co-authored-by: Aritra Sen <sena@sena0MD6R.vmware.com>
(cherry picked from commit af504c145ad5ff8485682b0fd67d12a126836606)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/350)
<!-- Reviewable:end -->
