### PR TITLE
Update load balancer e2e test for ip space setups

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	clusterId string
-	host      string
-	org       string
-	userOrg   string
-	ovdcName  string
-	username  string
-	token     string
+	clusterId   string
+	host        string
+	org         string
+	userOrg     string
+	ovdcName    string
+	username    string
+	token       string
+	useIpSpaces string
 
 	ContainerImage string
 )
@@ -35,6 +36,8 @@ func init() {
 	flag.StringVar(&username, "username", "", "Username for login to generate client")
 	flag.StringVar(&token, "token", "", "Refresh token of user to generate client")
 	flag.StringVar(&clusterId, "clusterId", "", "Cluster ID to fetch cluster RDE")
+	// jenkins boolean param gets auto converted to string when passed in as params
+	flag.StringVar(&useIpSpaces, "useIpSpaces", "false", "Set to 'true' if the gateway supports Ip Spaces")
 }
 
 var _ = BeforeSuite(func() {
@@ -46,6 +49,7 @@ var _ = BeforeSuite(func() {
 	Expect(username).NotTo(BeEmpty(), "Please make sure --username is set correctly.")
 	Expect(token).NotTo(BeEmpty(), "Please make sure --token is set correctly.")
 	Expect(clusterId).NotTo(BeEmpty(), "Please make sure --clusterId is set correctly.")
+	// useIpSpaces will default to "false"
 
 	// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
 	useAirgap := os.Getenv("AIRGAP")


### PR DESCRIPTION
Current load balancer tests rely on IP block based network/gateway and will fail if ran against an IP Space based network/gateway.

Added early returns in these tests to make sure they run against only infra they were written for.