### PR TITLE
[VKCI-306] get the gateway using the org object instead of the VDC

### DIFF
--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1468,12 +1468,16 @@ func (gm *GatewayManager) IsNSXTBackedGateway() bool {
 // in case the code is unable to determine the required info, it will return false with an error.
 func (gm *GatewayManager) IsUsingIpSpaces() (bool, error) {
 	edgeGatewayName := gm.GatewayRef.Name
-	vdc := gm.Client.VDC
-	if vdc == nil {
-		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. nil VDC object in client", edgeGatewayName)
-	}
-	edgeGateway, err := vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	edgeGatewayID := gm.GatewayRef.Id
+	clusterOrg, err := gm.Client.VCDClient.GetOrgByName(gm.Client.ClusterOrgName)
 	if err != nil {
+		return false, fmt.Errorf("error retrieving org [%s]: [%v]", gm.Client.ClusterOrgName, err)
+	}
+	if clusterOrg == nil || clusterOrg.Org == nil {
+		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not; obtained nil org", edgeGatewayName)
+	}
+	edgeGateway, err := clusterOrg.GetNsxtEdgeGatewayById(edgeGatewayID)
+	if err == nil {
 		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. error [%v]", edgeGatewayName, err)
 	}
 


### PR DESCRIPTION
If the OVDC network is a DC group network, `vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)` will return "EntityNotFound" error. This is because the govcd function will internally filter with `"ownerRef.id=="+vdc.Vdc.ID` and the `ownerRef.id` in case of  a DC group network is the ID of the DC group.

The solution used in this PR is to use the `org` GoVCD object to fetch the `edgeGateway` object.

Testing: Used this code in CAPVCD and saw that a right response is given for `IsUsingIPSpace()` function
