### PR TITLE
[VKCi-310] fix logic for searching VMs for a no-zone cluster

### DIFF
--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -101,14 +101,17 @@ func (vmic *VmInfoCache) SearchVMAcrossVDCs(vmName string, vmId string) (*govcd.
 	}
 
 	var ovdcNameList []string = nil
+	var isMultiZoneCluster bool
 	if vmic.zm != nil {
 		for key, _ := range vmic.zm.VdcToZoneMap {
 			ovdcNameList = append(ovdcNameList, key)
 		}
+		isMultiZoneCluster = true
 	} else {
 		ovdcNameList = []string{
 			vmic.client.ClusterOVDCName,
 		}
+		isMultiZoneCluster = false
 	}
 
 	orgManager := vcdsdk.OrgManager{
@@ -116,7 +119,7 @@ func (vmic *VmInfoCache) SearchVMAcrossVDCs(vmName string, vmId string) (*govcd.
 		OrgName: vmic.client.ClusterOrgName,
 	}
 
-	return orgManager.SearchVMAcrossVDCs(vmName, vmic.clusterVAppName, vmId, ovdcNameList)
+	return orgManager.SearchVMAcrossVDCs(vmName, vmic.clusterVAppName, vmId, ovdcNameList, isMultiZoneCluster)
 }
 
 func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {

--- a/pkg/vcdsdk/org.go
+++ b/pkg/vcdsdk/org.go
@@ -76,7 +76,7 @@ func (orgManager *OrgManager) GetComputePolicyDetailsFromName(computePolicyName 
 }
 
 func (orgManager *OrgManager) SearchVMAcrossVDCs(vmName string, clusterName string, vmId string,
-	ovdcNameList []string) (*govcd.VM, string, error) {
+	ovdcNameList []string, isMultiZoneCluster bool) (*govcd.VM, string, error) {
 
 	org, err := orgManager.Client.VCDClient.GetOrgByName(orgManager.OrgName)
 	if err != nil {
@@ -93,12 +93,14 @@ func (orgManager *OrgManager) SearchVMAcrossVDCs(vmName string, clusterName stri
 				ovdcName, orgManager.OrgName, err)
 			continue
 		}
-
-		vAppNamePrefix, err := CreateVAppNamePrefix(clusterName, vdc.Vdc.ID)
-		if err != nil {
-			klog.Infof("Unable to create a vApp name prefix for cluster [%s] in OVDC [%s] with OVDC ID [%s]: [%v]",
-				clusterName, vdc.Vdc.Name, vdc.Vdc.ID, err)
-			continue
+		vAppNamePrefix := clusterName
+		if isMultiZoneCluster {
+			vAppNamePrefix, err = CreateVAppNamePrefix(clusterName, vdc.Vdc.ID)
+			if err != nil {
+				klog.Infof("Unable to create a vApp name prefix for cluster [%s] in OVDC [%s] with OVDC ID [%s]: [%v]",
+					clusterName, vdc.Vdc.Name, vdc.Vdc.ID, err)
+				continue
+			}
 		}
 
 		klog.Infof("Looking for vApps with a prefix of [%s]", vAppNamePrefix)


### PR DESCRIPTION
use vapp name as the cluster name in a no-zone cluster.
