### PR TITLE
VKCI-312: Allow OVDC name or ID to be passed as an input parameter

### DIFF
--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -183,7 +183,7 @@ func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID
 	status, err := vmInfo.vm.GetStatus()
 	if err != nil {
 		vdcManager, vdcManagerErr := vcdsdk.NewVDCManager(i.vmInfoCache.client, i.vmInfoCache.client.ClusterOrgName,
-			i.vmInfoCache.client.ClusterOVDCName)
+			i.vmInfoCache.client.ClusterOVDCIdentifier)
 		if vdcManagerErr != nil {
 			return false, fmt.Errorf("error creating VDC manager object: [%v]", err)
 		}

--- a/pkg/ccm/instancesv2.go
+++ b/pkg/ccm/instancesv2.go
@@ -81,7 +81,7 @@ func (i instancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool,
 	status, err := vmInfo.vm.GetStatus()
 	if err != nil {
 		vdcManager, vdcManagerErr := vcdsdk.NewVDCManager(i.vmInfoCache.client, i.vmInfoCache.client.ClusterOrgName,
-			i.vmInfoCache.client.ClusterOVDCName)
+			i.vmInfoCache.client.ClusterOVDCIdentifier)
 		if vdcManagerErr != nil {
 			return false, fmt.Errorf("error creating VDC manager object: [%v]", err)
 		}

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -100,16 +100,16 @@ func (vmic *VmInfoCache) SearchVMAcrossVDCs(vmName string, vmId string) (*govcd.
 		return nil, "", fmt.Errorf("error while obtaining access token: [%v]", err)
 	}
 
-	var ovdcNameList []string = nil
+	var ovdcIdentifierList []string = nil
 	var isMultiZoneCluster bool
 	if vmic.zm != nil {
 		for key, _ := range vmic.zm.VdcToZoneMap {
-			ovdcNameList = append(ovdcNameList, key)
+			ovdcIdentifierList = append(ovdcIdentifierList, key)
 		}
 		isMultiZoneCluster = true
 	} else {
-		ovdcNameList = []string{
-			vmic.client.ClusterOVDCName,
+		ovdcIdentifierList = []string{
+			vmic.client.ClusterOVDCIdentifier,
 		}
 		isMultiZoneCluster = false
 	}
@@ -119,7 +119,7 @@ func (vmic *VmInfoCache) SearchVMAcrossVDCs(vmName string, vmId string) (*govcd.
 		OrgName: vmic.client.ClusterOrgName,
 	}
 
-	return orgManager.SearchVMAcrossVDCs(vmName, vmic.clusterVAppName, vmId, ovdcNameList, isMultiZoneCluster)
+	return orgManager.SearchVMAcrossVDCs(vmName, vmic.clusterVAppName, vmId, ovdcIdentifierList, isMultiZoneCluster)
 }
 
 func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {

--- a/pkg/vcdsdk/client.go
+++ b/pkg/vcdsdk/client.go
@@ -19,13 +19,13 @@ import (
 
 // Client :
 type Client struct {
-	VCDAuthConfig   *VCDAuthConfig // s
-	ClusterOrgName  string
-	ClusterOVDCName string
-	VCDClient       *govcd.VCDClient
-	VDC             *govcd.Vdc // TODO: Incrementally remove and test in tests
-	APIClient       *swaggerClient37.APIClient
-	RWLock          sync.RWMutex
+	VCDAuthConfig         *VCDAuthConfig
+	ClusterOrgName        string
+	ClusterOVDCIdentifier string
+	VCDClient             *govcd.VCDClient
+	VDC                   *govcd.Vdc // TODO: Incrementally remove and test in tests
+	APIClient             *swaggerClient37.APIClient
+	RWLock                sync.RWMutex
 }
 
 func GetUserAndOrg(fullUserName string, clusterOrg string, currentUserOrg string) (userOrg string, userName string, err error) {
@@ -98,7 +98,7 @@ func (client *Client) RefreshBearerToken() error {
 			return fmt.Errorf("unable to get vcd organization [%s]: [%v]",
 				client.ClusterOrgName, err)
 		}
-		vdc, err := org.GetVDCByName(client.ClusterOVDCName, true)
+		vdc, err := org.GetVDCByNameOrId(client.ClusterOVDCIdentifier, true)
 		if err != nil {
 			return fmt.Errorf("unable to get VDC from org [%s], VDC [%s]: [%v]",
 				client.ClusterOrgName, client.VCDAuthConfig.VDC, err)
@@ -138,7 +138,7 @@ func (client *Client) RefreshBearerToken() error {
 // host, orgName, userOrg, refreshToken, insecure, user, password
 
 // New method from (vdcClient, vdcName) return *govcd.Vdc
-func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOrg string,
+func NewVCDClientFromSecrets(host string, orgName string, vdcIdentifier string, userOrg string,
 	user string, password string, refreshToken string, insecure bool, getVdcClient bool) (*Client, error) {
 
 	// TODO: validation of parameters
@@ -178,11 +178,11 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 	}
 
 	client := &Client{
-		VCDAuthConfig:   vcdAuthConfig,
-		ClusterOrgName:  orgName,
-		ClusterOVDCName: vdcName,
-		VCDClient:       vcdClient,
-		APIClient:       apiClient,
+		VCDAuthConfig:         vcdAuthConfig,
+		ClusterOrgName:        orgName,
+		ClusterOVDCIdentifier: vdcIdentifier,
+		VCDClient:             vcdClient,
+		APIClient:             apiClient,
 	}
 
 	if getVdcClient {
@@ -191,9 +191,9 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 			return nil, fmt.Errorf("unable to get org from name [%s]: [%v]", orgName, err)
 		}
 
-		client.VDC, err = org.GetVDCByName(vdcName, true)
+		client.VDC, err = org.GetVDCByNameOrId(vdcIdentifier, true)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get VDC [%s] from org [%s]: [%v]", vdcName, orgName, err)
+			return nil, fmt.Errorf("unable to get VDC [%s] from org [%s]: [%v]", vdcIdentifier, orgName, err)
 		}
 	}
 	client.VCDClient = vcdClient

--- a/pkg/vcdsdk/org.go
+++ b/pkg/vcdsdk/org.go
@@ -76,21 +76,21 @@ func (orgManager *OrgManager) GetComputePolicyDetailsFromName(computePolicyName 
 }
 
 func (orgManager *OrgManager) SearchVMAcrossVDCs(vmName string, clusterName string, vmId string,
-	ovdcNameList []string, isMultiZoneCluster bool) (*govcd.VM, string, error) {
+	ovdcIdentifierList []string, isMultiZoneCluster bool) (*govcd.VM, string, error) {
 
 	org, err := orgManager.Client.VCDClient.GetOrgByName(orgManager.OrgName)
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to get org by name [%s]: [%v]", orgManager.OrgName, err)
 	}
 
-	for _, ovdcName := range ovdcNameList {
+	for _, ovdcIdentifier := range ovdcIdentifierList {
 		klog.Infof("Looking for VM [name:%s],[id:%s] of cluster [%s] in OVDC [%s]",
-			vmName, vmId, clusterName, ovdcName)
+			vmName, vmId, clusterName, ovdcIdentifier)
 
-		vdc, err := org.GetVDCByName(ovdcName, true)
+		vdc, err := org.GetVDCByNameOrId(ovdcIdentifier, true)
 		if err != nil {
-			klog.Infof("unable to query VDC [%s] in Org [%s] by name: [%v]",
-				ovdcName, orgManager.OrgName, err)
+			klog.Infof("unable to query VDC [%s] in Org [%s] by identifier: [%v]",
+				ovdcIdentifier, orgManager.OrgName, err)
 			continue
 		}
 		vAppNamePrefix := clusterName
@@ -139,7 +139,7 @@ func (orgManager *OrgManager) SearchVMAcrossVDCs(vmName string, clusterName stri
 		}
 
 		klog.Infof("Could not find VM [name:%s],[id:%s] of cluster [%s] in OVDC [%s]",
-			vmName, vmId, clusterName, ovdcName)
+			vmName, vmId, clusterName, ovdcIdentifier)
 	}
 
 	return nil, "", govcd.ErrorEntityNotFound

--- a/pkg/vcdsdk/vapp_test.go
+++ b/pkg/vcdsdk/vapp_test.go
@@ -28,7 +28,7 @@ func TestVApp(t *testing.T) {
 
 	// create vApp
 	vAppName := "test-vapp"
-	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCName)
+	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCIdentifier)
 	assert.NoError(t, err, "error creating VDCManager")
 
 	// create VApp
@@ -63,7 +63,7 @@ func TestDeleteVapp(t *testing.T) {
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
 	vappName := "vapp1"
-	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCName)
+	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCIdentifier)
 	assert.NoError(t, err, "there should be no error in creating VDCManager object")
 	vapp, err := vdcManager.GetOrCreateVApp(vappName, vcdConfig.OvdcNetwork)
 	assert.NoError(t, err, "unable to find vApp")
@@ -90,7 +90,7 @@ func TestVdcManager_CacheVdcDetails(t *testing.T) {
 	assert.NoError(t, err, "Unable to get VCD client")
 	require.NotNil(t, vcdClient, "VCD Client should not be nil")
 
-	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCName)
+	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCIdentifier)
 	err = vdcManager.cacheVdcDetails()
 	assert.NoError(t, err, "There should no error while caching VDC details")
 }
@@ -107,7 +107,7 @@ func TestVMCreation(t *testing.T) {
 
 	// create vApp
 	vAppName := "test-vapp"
-	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCName)
+	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCIdentifier)
 	assert.NoError(t, err, "there should be no error when creating VDCManager object")
 
 	vApp, err := vdcManager.GetOrCreateVApp(vAppName, vcdConfig.OvdcNetwork)
@@ -181,7 +181,7 @@ func TestVMExtraConfig(t *testing.T) {
 
 	// create vApp
 	vAppName := "test-vapp"
-	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCName)
+	vdcManager, err := NewVDCManager(vcdClient, vcdClient.ClusterOrgName, vcdClient.ClusterOVDCIdentifier)
 	assert.NoError(t, err, "there should be no error when creating VDCManager object")
 
 	vApp, err := vdcManager.GetOrCreateVApp(vAppName, vcdConfig.OvdcNetwork)


### PR DESCRIPTION
This change brings in the option to either use an OVDC name or an OVDC ID for all operations.

This change does not support rename of OVDC names. If a user wants to rename in the future, they can use an ID rather than a name. So the onus is shifted to the client in deciding what to use to represent OVDCs.

In the case of CPI, the client is CSE and Kubernetes CLI.