### PR TITLE
[VKCI-313] error in the CPI manifests - missed mountPath in config

### DIFF
--- a/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
+++ b/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
@@ -166,6 +166,8 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+            - name: vcloud-capvcd-zones-volume
+              mountPath: /opt/vmware-cloud-director/ccm
           env:
             - name: CLUSTER_ID
               valueFrom:

--- a/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
+++ b/artifacts/default-cloud-director-ccm-crs-airgap.yaml.template
@@ -195,7 +195,7 @@ spec:
         - name: vcloud-ccm-config-volume
           configMap:
             name: vcloud-ccm-configmap
-        - name: vcloud-capvcd-zones
+        - name: vcloud-capvcd-zones-volume
           configMap:
             name: vcloud-capvcd-zones
         - name: vcloud-ccm-vcloud-basic-auth-volume

--- a/manifests/cloud-director-ccm-crs.yaml
+++ b/manifests/cloud-director-ccm-crs.yaml
@@ -164,6 +164,8 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+            - name: vcloud-capvcd-zones-volume
+              mountPath: /opt/vmware-cloud-director/ccm
           env:
           - name: CLUSTER_ID
             valueFrom:
@@ -191,7 +193,7 @@ spec:
         - name: vcloud-ccm-config-volume
           configMap:
             name: vcloud-ccm-configmap
-        - name: vcloud-capvcd-zones
+        - name: vcloud-capvcd-zones-volume
           configMap:
             name: vcloud-capvcd-zones
         - name: vcloud-ccm-vcloud-basic-auth-volume

--- a/manifests/cloud-director-ccm-crs.yaml.template
+++ b/manifests/cloud-director-ccm-crs.yaml.template
@@ -193,7 +193,7 @@ spec:
         - name: vcloud-ccm-config-volume
           configMap:
             name: vcloud-ccm-configmap
-        - name: vcloud-capvcd-zones
+        - name: vcloud-capvcd-zones-volume
           configMap:
             name: vcloud-capvcd-zones
         - name: vcloud-ccm-vcloud-basic-auth-volume

--- a/manifests/cloud-director-ccm-crs.yaml.template
+++ b/manifests/cloud-director-ccm-crs.yaml.template
@@ -164,6 +164,8 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+            - name: vcloud-capvcd-zones-volume
+              mountPath: /opt/vmware-cloud-director/ccm
           env:
           - name: CLUSTER_ID
             valueFrom:

--- a/manifests/cloud-director-ccm.yaml
+++ b/manifests/cloud-director-ccm.yaml
@@ -164,6 +164,8 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+            - name: vcloud-capvcd-zones-volume
+              mountPath: /opt/vmware-cloud-director/ccm
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
@@ -185,7 +187,7 @@ spec:
         - name: vcloud-ccm-config-volume
           configMap:
             name: vcloud-ccm-configmap
-        - name: vcloud-capvcd-zones
+        - name: vcloud-capvcd-zones-volume
           configMap:
             name: vcloud-capvcd-zones
         - name: vcloud-ccm-vcloud-basic-auth-volume

--- a/manifests/cloud-director-ccm.yaml.template
+++ b/manifests/cloud-director-ccm.yaml.template
@@ -164,6 +164,8 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+            - name: vcloud-capvcd-zones-volume
+              mountPath: /opt/vmware-cloud-director/ccm
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
@@ -185,7 +187,7 @@ spec:
         - name: vcloud-ccm-config-volume
           configMap:
             name: vcloud-ccm-configmap
-        - name: vcloud-capvcd-zones
+        - name: vcloud-capvcd-zones-volume
           configMap:
             name: vcloud-capvcd-zones
         - name: vcloud-ccm-vcloud-basic-auth-volume


### PR DESCRIPTION
When zone config map was added to the manifests, a mount path was missed to make it accessible by CPI code