### PR TITLE
VKCI-314: fixup regressions in using OVDC ID

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -43,14 +43,14 @@ type LBManager struct {
 	CertificateAlias             string
 	OneArm                       *vcdsdk.OneArm
 	ovdcNetworkName              string
-	ovdcName                     string
+	ovdcIdentifier               string
 	ipamSubnet                   string
 	clusterID                    string
 	EnableVirtualServiceSharedIP bool
 }
 
 func newLoadBalancer(vcdClient *vcdsdk.Client, certAlias string, oneArm *vcdsdk.OneArm,
-	ovdcNetworkName string, ovdcName string, ipamSubnet string, clusterID string, enableVirtualServiceSharedIP bool) cloudProvider.LoadBalancer {
+	ovdcNetworkName string, ovdcIdentifier string, ipamSubnet string, clusterID string, enableVirtualServiceSharedIP bool) cloudProvider.LoadBalancer {
 
 	return &LBManager{
 		vcdClient:                    vcdClient,
@@ -59,7 +59,7 @@ func newLoadBalancer(vcdClient *vcdsdk.Client, certAlias string, oneArm *vcdsdk.
 		CertificateAlias:             certAlias,
 		OneArm:                       oneArm,
 		ovdcNetworkName:              ovdcNetworkName,
-		ovdcName:                     ovdcName,
+		ovdcIdentifier:               ovdcIdentifier,
 		ipamSubnet:                   ipamSubnet,
 		clusterID:                    clusterID,
 		EnableVirtualServiceSharedIP: enableVirtualServiceSharedIP,
@@ -221,7 +221,7 @@ func (lb *LBManager) UpdateLoadBalancer(ctx context.Context, clusterName string,
 		lbPoolName := fmt.Sprintf("%s-%s", lbPoolNamePrefix, portName)
 		virtualServiceName := fmt.Sprintf("%s-%s", virtualServiceNamePrefix, portName)
 		externalPort := typeToExternalPort[portName]
-		gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcName)
+		gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcIdentifier)
 		if err != nil {
 			return fmt.Errorf("error while creating GatewayManager: [%v]", err)
 		}
@@ -290,7 +290,7 @@ func (lb *LBManager) getLoadBalancer(ctx context.Context,
 
 	virtualServiceNamePrefix := lb.getLoadBalancerPrefix(ctx, service)
 	virtualIP := ""
-	gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcName)
+	gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcIdentifier)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while creating GatewayManager: [%v]", err)
 	}
@@ -435,7 +435,7 @@ func (lb *LBManager) deleteLoadBalancer(ctx context.Context, service *v1.Service
 	}
 	klog.Infof("Deleting loadbalancer for ports [%#v]\n", portDetailsList)
 
-	gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcName)
+	gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcIdentifier)
 	if err != nil {
 		return fmt.Errorf("error while creating GatewayManager: [%v]", err)
 	}
@@ -549,7 +549,7 @@ func (lb *LBManager) createLoadBalancer(ctx context.Context, service *v1.Service
 	if removeErr != nil {
 		klog.Errorf("error adding CPI error [%s] to the RDE [%s], [%v]", cpisdk.GetLoadbalancerError, lb.clusterID, removeErr)
 	}
-	gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcName)
+	gm, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcIdentifier)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating GatewayManager: [%v]", err)
 	}
@@ -757,7 +757,7 @@ to search for a virtual service of %s name.
 func (lb *LBManager) verifyVCDResourcesForApplicationLB(ctx context.Context, virtualServiceNamePrefix string,
 	lbPoolNamePrefix string, portDetailsList []vcdsdk.PortDetails, oneArm *vcdsdk.OneArm) (bool, error) {
 
-	gatewayMgr, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcName)
+	gatewayMgr, err := vcdsdk.NewGatewayManager(ctx, lb.vcdClient, lb.ovdcNetworkName, lb.ipamSubnet, lb.ovdcIdentifier)
 	if err != nil {
 		return false, fmt.Errorf("error creating new gateway manager [%v]", err)
 	}

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -51,7 +51,7 @@ func newVmInfoCache(client *vcdsdk.Client, clusterVAppName string, expiry time.D
 	}
 }
 
-func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, ovdc string, captureTime time.Time) (*VmInfo, error) {
+func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, ovdcIdentifier string, captureTime time.Time) (*VmInfo, error) {
 
 	if vm == nil {
 		return nil, fmt.Errorf("vm parameter should not be nil")
@@ -62,7 +62,7 @@ func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, ovdc string, captureTime time.
 
 	vmInfo := &VmInfo{
 		vm:        vm,
-		OVDC:      ovdc,
+		OVDC:      ovdcIdentifier,
 		UUID:      vm.VM.ID,
 		Name:      vm.VM.Name,
 		Type:      "",
@@ -137,13 +137,13 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 		delete(vmic.nameMap, vmName)
 	}
 
-	vm, ovdcName, err := vmic.SearchVMAcrossVDCs(vmName, "")
+	vm, ovdcIdentifier, err := vmic.SearchVMAcrossVDCs(vmName, "")
 	if err != nil {
 		return nil, fmt.Errorf("unable to find VM [%s] in org [%s] for cluster [%s]: [%v]",
 			vmName, vmic.client.ClusterOrgName, vmic.clusterVAppName, err)
 	}
 
-	vmInfo, err := vmic.vmToVMInfo(vm, ovdcName, time.Now())
+	vmInfo, err := vmic.vmToVMInfo(vm, ovdcIdentifier, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert vm struct [%v] to vmInfo: [%v]", vm, err)
 	}
@@ -168,13 +168,13 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 		// don't use old values
 		delete(vmic.nameMap, vmUUID)
 	}
-	vm, ovdcName, err := vmic.SearchVMAcrossVDCs("", vmUUID)
+	vm, ovdcIdentifier, err := vmic.SearchVMAcrossVDCs("", vmUUID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find VM [%s] in org [%s] for cluster [%s]: [%v]",
 			vmUUID, vmic.client.ClusterOrgName, vmic.clusterVAppName, err)
 	}
 
-	vmInfo, err := vmic.vmToVMInfo(vm, ovdcName, time.Now())
+	vmInfo, err := vmic.vmToVMInfo(vm, ovdcIdentifier, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert vm struct [%v] to vmInfo: [%v]", vm, err)
 	}

--- a/pkg/testingsdk/client.go
+++ b/pkg/testingsdk/client.go
@@ -24,13 +24,13 @@ type TestClient struct {
 }
 
 type VCDAuthParams struct {
-	Host         string
-	OvdcName     string
-	OrgName      string
-	Username     string
-	RefreshToken string
-	UserOrg      string
-	GetVdcClient bool // This will need to be set to true as it's needed for CSI, but may not be needed for other use cases
+	Host           string
+	OvdcIdentifier string
+	OrgName        string
+	Username       string
+	RefreshToken   string
+	UserOrg        string
+	GetVdcClient   bool // This will need to be set to true as it's needed for CSI, but may not be needed for other use cases
 }
 
 type DeployParams struct {

--- a/pkg/testingsdk/vcd_utils.go
+++ b/pkg/testingsdk/vcd_utils.go
@@ -12,7 +12,7 @@ func getTestVCDClient(params *VCDAuthParams) (*vcdsdk.Client, error) {
 	return vcdsdk.NewVCDClientFromSecrets(
 		params.Host,
 		params.OrgName,
-		params.OvdcName,
+		params.OvdcIdentifier,
 		params.UserOrg,
 		params.Username,
 		"",

--- a/tests/e2e/utils/cpi_vcd_utils.go
+++ b/tests/e2e/utils/cpi_vcd_utils.go
@@ -11,15 +11,15 @@ import (
 	"strings"
 )
 
-func NewTestClient(host, org, userOrg, vdcName, username, token, clusterId string, getVdcClient bool) (*testingsdk.TestClient, error) {
+func NewTestClient(host, org, userOrg, ovdcIdentifier, username, token, clusterId string, getVdcClient bool) (*testingsdk.TestClient, error) {
 	vcdAuthParams := &testingsdk.VCDAuthParams{
-		Host:         host,
-		OrgName:      org,
-		UserOrg:      userOrg,
-		OvdcName:     vdcName,
-		Username:     username,
-		RefreshToken: token,
-		GetVdcClient: getVdcClient,
+		Host:           host,
+		OrgName:        org,
+		UserOrg:        userOrg,
+		OvdcIdentifier: ovdcIdentifier,
+		Username:       username,
+		RefreshToken:   token,
+		GetVdcClient:   getVdcClient,
 	}
 	return testingsdk.NewTestClient(vcdAuthParams, clusterId)
 }


### PR DESCRIPTION
In some cases, the name was compared and used. This change fixes up those cases as well.
1. There was a comparison of the identifier with the vdc.Name. This was fixed.
2. There were numerous places where the ovdcName was used as a variable. This has also been fixed.