### PR TITLE
VKCI-317: Handle null OVDC in OVDCNetwork lookup

### DIFF
--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -121,8 +121,9 @@ func (gm *GatewayManager) getOVDCNetwork(ctx context.Context, networkName string
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if ovdcNetwork.Name == gm.NetworkName && ovdcNetwork.OrgVdc != nil &&
-				(ovdcNetwork.OrgVdc.Name == ovdcIdentifier ||
+			if ovdcNetwork.Name == gm.NetworkName &&
+				(ovdcNetwork.OrgVdc == nil ||
+					ovdcNetwork.OrgVdc.Name == ovdcIdentifier ||
 					ovdcNetwork.OrgVdc.Id == ovdcIdentifier) {
 				if networkFound {
 					return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - "+


### PR DESCRIPTION
DC Group networks return a nil OVDC