### PR TITLE
[VKCI-256, VKCI-320] Update ginkgo tests for multi az scenario

### DIFF
--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -170,6 +170,9 @@ func (vmic *VmInfoCache) GetByUUID(vmUUID string) (*VmInfo, error) {
 	}
 	vm, ovdcIdentifier, err := vmic.SearchVMAcrossVDCs("", vmUUID)
 	if err != nil {
+		if err == govcd.ErrorEntityNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("unable to find VM [%s] in org [%s] for cluster [%s]: [%v]",
 			vmUUID, vmic.client.ClusterOrgName, vmic.clusterVAppName, err)
 	}

--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -139,6 +139,9 @@ func (vmic *VmInfoCache) GetByName(vmName string) (*VmInfo, error) {
 
 	vm, ovdcIdentifier, err := vmic.SearchVMAcrossVDCs(vmName, "")
 	if err != nil {
+		if err == govcd.ErrorEntityNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("unable to find VM [%s] in org [%s] for cluster [%s]: [%v]",
 			vmName, vmic.client.ClusterOrgName, vmic.clusterVAppName, err)
 	}

--- a/pkg/testingsdk/client.go
+++ b/pkg/testingsdk/client.go
@@ -218,7 +218,7 @@ func (tc *TestClient) GetZoneMapFromZoneConfigMap(zoneCM *apiv1.ConfigMap) (map[
 
 	zoneMap := make(map[string]string)
 	for _, zoneInfoIf := range zoneInfoList {
-		zoneInfo, ok := zoneInfoIf.(map[string]string)
+		zoneInfo, ok := zoneInfoIf.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("failed to convert zone entry in zone config map [%v] to map[string]string", zoneInfoIf)
 		}
@@ -230,7 +230,9 @@ func (tc *TestClient) GetZoneMapFromZoneConfigMap(zoneCM *apiv1.ConfigMap) (map[
 		if !ok {
 			return nil, fmt.Errorf("zone entry in zone map doesn't have OVDC name")
 		}
-		zoneMap[name] = ovdcName
+		nameStr := name.(string)
+		ovdcNameStr := ovdcName.(string)
+		zoneMap[nameStr] = ovdcNameStr
 	}
 	return zoneMap, nil
 }

--- a/pkg/testingsdk/client.go
+++ b/pkg/testingsdk/client.go
@@ -193,6 +193,48 @@ func (tc *TestClient) GetK8sVersion() (*version.Info, error) {
 	return tc.Cs.(*kubernetes.Clientset).Discovery().ServerVersion()
 }
 
+// GetZoneMapFromZoneConfigMap reads the zone config map and returns a map of zoneName -> ovdcName
+func (tc *TestClient) GetZoneMapFromZoneConfigMap(zoneCM *apiv1.ConfigMap) (map[string]string, error) {
+	data := zoneCM.Data
+
+	zoneYaml, ok := data["vcloud-cse-zones.yaml"]
+	if !ok {
+		return nil, fmt.Errorf("no data present")
+	}
+	var zoneCfgMap map[string]interface{}
+	err := yaml.Unmarshal([]byte(zoneYaml), &zoneCfgMap)
+	if err != nil {
+		return nil, fmt.Errorf("err occurred: [%v]", err)
+	}
+	zoneInfoListIf, ok := zoneCfgMap["zones"]
+	if !ok {
+		return nil, fmt.Errorf("zone config map doesn't have zone list")
+	}
+
+	zoneInfoList, ok := zoneInfoListIf.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert zoneInfoList interface to array")
+	}
+
+	zoneMap := make(map[string]string)
+	for _, zoneInfoIf := range zoneInfoList {
+		zoneInfo, ok := zoneInfoIf.(map[string]string)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert zone entry in zone config map [%v] to map[string]string", zoneInfoIf)
+		}
+		name, ok := zoneInfo["name"]
+		if !ok {
+			return nil, fmt.Errorf("zone entry in zone map doesn't have a zone name")
+		}
+		ovdcName, ok := zoneInfo["ovdcName"]
+		if !ok {
+			return nil, fmt.Errorf("zone entry in zone map doesn't have OVDC name")
+		}
+		zoneMap[name] = ovdcName
+	}
+	return zoneMap, nil
+}
+
 func (tc *TestClient) GetIpamSubnetFromConfigMap(cm *apiv1.ConfigMap) (string, error) {
 	data := cm.Data
 	ccmYaml, ok := data["vcloud-ccm-config.yaml"]

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -18,6 +18,7 @@ var (
 	username    string
 	token       string
 	useIpSpaces string
+	isMultiAZ   string
 
 	ContainerImage string
 )
@@ -38,6 +39,8 @@ func init() {
 	flag.StringVar(&clusterId, "clusterId", "", "Cluster ID to fetch cluster RDE")
 	// jenkins boolean param gets auto converted to string when passed in as params
 	flag.StringVar(&useIpSpaces, "useIpSpaces", "false", "Set to 'true' if the gateway supports Ip Spaces")
+	// isMultiAz cluster boolean param is assigned to true to run tests for a multi AZ cluster
+	flag.StringVar(&isMultiAZ, "isMultiAZ", "false", "Set to 'true' for a multi AZ cluster")
 }
 
 var _ = BeforeSuite(func() {
@@ -50,6 +53,7 @@ var _ = BeforeSuite(func() {
 	Expect(token).NotTo(BeEmpty(), "Please make sure --token is set correctly.")
 	Expect(clusterId).NotTo(BeEmpty(), "Please make sure --clusterId is set correctly.")
 	// useIpSpaces will default to "false"
+	// isMultiAZ will default to "false"
 
 	// AIRGAP environment variable is expected to be set in jenkins or by user via `export AIRGAP="true"`
 	useAirgap := os.Getenv("AIRGAP")

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -48,7 +48,6 @@ var _ = BeforeSuite(func() {
 	Expect(host).NotTo(BeEmpty(), "Please make sure --host is set correctly.")
 	Expect(org).NotTo(BeEmpty(), "Please make sure --org is set correctly.")
 	Expect(userOrg).NotTo(BeEmpty(), "Please make sure --userOrg is set correctly.")
-	Expect(ovdcName).NotTo(BeEmpty(), "Please make sure --ovdcName is set correctly.")
 	Expect(username).NotTo(BeEmpty(), "Please make sure --username is set correctly.")
 	Expect(token).NotTo(BeEmpty(), "Please make sure --token is set correctly.")
 	Expect(clusterId).NotTo(BeEmpty(), "Please make sure --clusterId is set correctly.")

--- a/tests/e2e/utils/cpi_vcd_utils.go
+++ b/tests/e2e/utils/cpi_vcd_utils.go
@@ -122,46 +122,26 @@ func HasVCDResourcesForApplicationLB(ctx context.Context, testClient *testingsdk
 		vsFound, lbPoolFound, dnatRuleFound, appPortProfileFound, oneArm)
 }
 
-func GetOvdcByName(tc *testingsdk.TestClient, vdcName string) (*govcd.Vdc, error) {
-	if tc == nil || tc.VcdClient == nil {
-		return nil, fmt.Errorf("testing client not initialized")
-	}
-	org, err := tc.VcdClient.VCDClient.GetOrgByName(tc.VcdClient.ClusterOrgName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get org [%s] by name", tc.VcdClient.ClusterOrgName)
-	}
-	vdc, err := org.GetVDCByName(vdcName, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get VDC [%s] by name from org [%s]", vdcName, tc.VcdClient.ClusterOrgName)
-	}
-	return vdc, nil
-}
-
 func getTrimmedClusterID(clusterId string) string {
 	return strings.TrimPrefix(clusterId, clusterUrnPrefix)
 }
 
-func GetVDCForZone(tc *testingsdk.TestClient, zoneName string) (*govcd.Vdc, error) {
-	zoneConfigMap, err := tc.GetConfigMap(VCloudZoneConfigMapName, VCloudZoneConfigMapNamespace)
+func GetVDCForZone(tc *testingsdk.TestClient, zoneName string) (string, error) {
+	zoneConfigMap, err := tc.GetConfigMap(VCloudZoneConfigMapNamespace, VCloudZoneConfigMapName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the zone config map: [%v]", err)
+		return "", fmt.Errorf("failed to get the zone config map: [%v]", err)
 	}
 	if zoneConfigMap == nil {
-		return nil, fmt.Errorf("zone config map is nil")
+		return "", fmt.Errorf("zone config map is nil")
 	}
 	zoneToOVDC, err := tc.GetZoneMapFromZoneConfigMap(zoneConfigMap)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get zone name to ovdc name mapping: [%v]", err)
+		return "", fmt.Errorf("failed to get zone name to ovdc name mapping: [%v]", err)
 	}
 
 	ovdcName, ok := zoneToOVDC[zoneName]
 	if !ok {
-		return nil, fmt.Errorf("zone config map doesn't have an entry for the zone name")
+		return "", fmt.Errorf("zone config map doesn't have an entry for the zone name")
 	}
-
-	vdc, err := GetOvdcByName(tc, ovdcName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find OVDC by name [%s]: [%v]", ovdcName, err)
-	}
-	return vdc, nil
+	return ovdcName, nil
 }

--- a/tests/e2e/utils/node_utils.go
+++ b/tests/e2e/utils/node_utils.go
@@ -8,6 +8,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"strings"
 	"time"
 )
 
@@ -42,4 +43,20 @@ func WaitForWorkerNodeNotFound(ctx context.Context, tc *testingsdk.TestClient, w
 		}
 		return false, nil
 	})
+}
+
+func GetVAppNameFromNode(clusterName string, machineSet string, ovdcID string) (string, error) {
+	parts := strings.Split(ovdcID, ":")
+	if len(parts) != 4 {
+		// urn:vcloud:ovdc:<uuid>
+		return "", fmt.Errorf("invalid URN format for OVDC: [%s]", ovdcID)
+	}
+	// machine set name will be mdName-abcd
+	endIndex := strings.LastIndex(machineSet, "-")
+	if endIndex == -1 {
+		return "", fmt.Errorf("machine set name [%s] is not in an expected format", machineSet)
+	}
+	mdName := machineSet[:endIndex]
+	// <cluster_name>_<ovdc_id>_<machine_deployment_name>
+	return fmt.Sprintf("%s_%s_%s", clusterName, parts[3], mdName), nil
 }


### PR DESCRIPTION
Load Balancer CRUD tests do not change.
Node LCM tests need changes to search the node VM in a particular VDC.

This PR also contains a fix for one of the Node LCM tests where the node object is not deleted by CPI when the node VM is deleted in VCD

