### PR TITLE
use protocol instead of app protocol for health monitor type

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -11,6 +11,9 @@ package ccm
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/cpisdk"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/util"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
@@ -22,8 +25,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	cloudProvider "k8s.io/cloud-provider"
 	"k8s.io/klog"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -163,9 +164,7 @@ func (lb *LBManager) getServicePortMap(service *v1.Service) (map[string]int32, m
 	for _, port := range service.Spec.Ports {
 		typeToInternalPort[strings.ToLower(port.Name)] = port.NodePort
 		typeToExternalPort[strings.ToLower(port.Name)] = port.Port
-		if port.AppProtocol != nil {
-			nameToProtocol[strings.ToLower(port.Name)] = strings.ToUpper(*port.AppProtocol)
-		}
+		nameToProtocol[strings.ToLower(port.Name)] = strings.ToUpper(string(port.Protocol))
 	}
 	return typeToInternalPort, typeToExternalPort, nameToProtocol
 }


### PR DESCRIPTION
Solves the following bug: https://github.com/vmware/cloud-provider-for-cloud-director/issues/281

Previously, any TCP health monitors defined for a load balancer pool would be removed during an update of the pool which occurs for example during scaling of workers.

The reason is as follows: The TCP type health monitor is added based on the ports `Protocol` field being `TCP` when the load balancer pool is first formed as part of load balancer creation here: https://github.com/vmware/cloud-provider-for-cloud-director/blob/2d6e9efaf23df037d4cb1d58484bf04b3f2b8935/pkg/vcdsdk/gateway.go#L1754-L1755
However, in subsequent update cycles we were using the `appProtocol` field instead of the `protocol` one: https://github.com/vmware/cloud-provider-for-cloud-director/blob/2d6e9efaf23df037d4cb1d58484bf04b3f2b8935/pkg/ccm/loadbalancer.go#L167
This results in the health check being removed since only `TCP` type health checks are included in the first place as can be seen here: https://github.com/vmware/cloud-provider-for-cloud-director/blob/2d6e9efaf23df037d4cb1d58484bf04b3f2b8935/pkg/vcdsdk/gateway.go#L751-L752

This PR changes the code to use the ports `Protocol` also in update cases. The value being changed here is not used in any other functions and deploying this change resulted in health monitors to no longer be removed on update.