### PR TITLE
Add support for Datacenter Group network in CPI

### DIFF
--- a/pkg/vcdsdk/auth.go
+++ b/pkg/vcdsdk/auth.go
@@ -99,6 +99,7 @@ func (config *VCDAuthConfig) GetSwaggerClientFromSecrets() (*govcd.VCDClient, *s
 	swaggerConfig37.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Insecure},
+			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 	apiClient37 := swaggerClient.NewAPIClient(swaggerConfig37)

--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1468,11 +1468,15 @@ func (gm *GatewayManager) IsNSXTBackedGateway() bool {
 // in case the code is unable to determine the required info, it will return false with an error.
 func (gm *GatewayManager) IsUsingIpSpaces() (bool, error) {
 	edgeGatewayName := gm.GatewayRef.Name
-	vdc := gm.Client.VDC
-	if vdc == nil {
-		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. nil VDC object in client", edgeGatewayName)
+	edgeGatewayID := gm.GatewayRef.Id
+	clusterOrg, err := gm.Client.VCDClient.GetOrgByName(gm.Client.ClusterOrgName)
+	if err != nil {
+		return false, fmt.Errorf("error retrieving org [%s]: [%v]", gm.Client.ClusterOrgName, err)
 	}
-	edgeGateway, err := vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	if clusterOrg == nil || clusterOrg.Org == nil {
+		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not; obtained nil org", edgeGatewayName)
+	}
+	edgeGateway, err := clusterOrg.GetNsxtEdgeGatewayById(edgeGatewayID)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. error [%v]", edgeGatewayName, err)
 	}

--- a/pkg/vcdsdk/gateway.go
+++ b/pkg/vcdsdk/gateway.go
@@ -1474,11 +1474,11 @@ func (gm *GatewayManager) IsUsingIpSpaces() (bool, error) {
 		return false, fmt.Errorf("error retrieving org [%s]: [%v]", gm.Client.ClusterOrgName, err)
 	}
 	if clusterOrg == nil || clusterOrg.Org == nil {
-		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not; obtained nil org", edgeGatewayName)
+		return false, fmt.Errorf("unable to determine if gateway [%s] of org [%s] is using Ip Spaces or not; obtained nil org", edgeGatewayName, gm.Client.ClusterOrgName)
 	}
 	edgeGateway, err := clusterOrg.GetNsxtEdgeGatewayById(edgeGatewayID)
 	if err != nil {
-		return false, fmt.Errorf("unable to determine if gateway [%s] is using Ip Spaces or not. error [%v]", edgeGatewayName, err)
+		return false, fmt.Errorf("unable to determine if gateway [%s] of org [%s]  is using Ip Spaces or not. error [%v]", edgeGatewayName, gm.Client.ClusterOrgName, err)
 	}
 
 	edgeGatewayUplinks := edgeGateway.EdgeGateway.EdgeGatewayUplinks


### PR DESCRIPTION
CPI didn't support Datacenter Group networks because the method GetNsxtEdgeGatewayByName can't handle datacenter group networks. In this PR we have replaced the method with GetNsxtEdgeGatewayById to avoid the issue.

Additionally, added support for Proxy in SwaggerClient.

Testing done:
on a fresh VCD 10.5.1 setup
* Created an IP space
* Created IP space uplink in the PVDC
* Created two OrgVDC that are being powered by this PVDC
* Created a data center group from these two Org VDCs
* Created a stretched edge gateway and a data center org vdc network
* Ran the IP space test : TestGatewayUsingIpSpaces
```
=== RUN   TestGatewayUsingIpSpaces
I0724 14:39:24.036255   58260 auth.go:50] Using VCD OpenAPI version [37.2]
I0724 14:39:25.270434   58260 auth.go:74] Running module as sysadmin [false]
I0724 14:39:25.676547   58260 client.go:201] Client is sysadmin: [false]
I0724 14:39:26.703796   58260 gateway.go:70] Obtained Gateway [provider_vdc_edge] for Network Name [provider_orgvdc_net] of type [NSXT_FLEXIBLE_SEGMENT]
I0724 14:39:28.110271   58260 gateway.go:70] Obtained Gateway [provider_org_edge_no_ipspace] for Network Name [provider_orgvdc_net_no_ipspace] of type [NSXT_FLEXIBLE_SEGMENT]
--- PASS: TestGatewayUsingIpSpaces (4.34s)
PASS
```

The test passing proves that now CPI can handle Data center group networks.

Note : The VCD testbed is deployed in a private VLAN and can be accessed only via a proxy, hence the modification to SwaggerClient. Govcd client is already proxy aware.

Fixes : https://bugzilla.eng.vmware.com/show_bug.cgi?id=3397729